### PR TITLE
add kubectl env var

### DIFF
--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -81,3 +81,12 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.authenticate_prometheus=False \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
+
+echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -71,6 +71,8 @@ fi
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
+printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
+
 jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -82,11 +84,3 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
-echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -81,3 +81,12 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.authenticate_prometheus=False \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
+
+echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -71,6 +71,8 @@ fi
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
+printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
+
 jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -82,11 +84,3 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
-echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -81,3 +81,12 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.authenticate_prometheus=False \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
+
+echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -71,6 +71,8 @@ fi
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
+printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
+
 jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -82,11 +84,3 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
-echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -81,3 +81,12 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.authenticate_prometheus=False \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
+
+echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -71,6 +71,8 @@ fi
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
+printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
+
 jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -82,11 +84,3 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
-echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -81,3 +81,12 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.authenticate_prometheus=False \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
+
+echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -71,6 +71,8 @@ fi
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
+printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
+
 jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -82,11 +84,3 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
-echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -81,3 +81,12 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.authenticate_prometheus=False \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
+
+echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -71,6 +71,8 @@ fi
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
+printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
+
 jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -82,11 +84,3 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
-echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -81,3 +81,12 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.authenticate_prometheus=False \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
+
+echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
+echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
+echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -71,6 +71,8 @@ fi
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
+printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
+
 jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -82,11 +84,3 @@ jupyter server --notebook-dir=/home/${NB_USER} \
                  --ServerApp.base_url=${NB_PREFIX} \
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
-echo "KUBERNETES_SERVICE_PORT=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_SERVICE_PORT_HTTPS=443" >> /opt/conda/lib/R/etc/Renviron 
-echo "KUBERNETES_PORT_443_TCP=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_ADDR=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PROTO=tcp" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_SERVICE_HOST=10.135.0.1" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT=tcp://10.135.0.1:443" >> /opt/conda/lib/R/etc/Renviron
-echo "KUBERNETES_PORT_443_TCP_PORT=443" >> /opt/conda/lib/R/etc/Renviron


### PR DESCRIPTION
# Description

closes #272 
**What your PR adds/fixes/removes**
Adds kubernetes environment variables to Renviron file (stores all env var)

# Tests / Quality Checks

## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test (e.g. `k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
