### PR TITLE
fix(jupyter): use full path

### DIFF
--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -73,7 +73,7 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
-jupyter server --notebook-dir=/home/${NB_USER} \
+/opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
                  --port=8888 \

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -73,7 +73,7 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
-jupyter server --notebook-dir=/home/${NB_USER} \
+/opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
                  --port=8888 \

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -73,7 +73,7 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
-jupyter server --notebook-dir=/home/${NB_USER} \
+/opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
                  --port=8888 \

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -73,7 +73,7 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
-jupyter server --notebook-dir=/home/${NB_USER} \
+/opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
                  --port=8888 \

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -73,7 +73,7 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
-jupyter server --notebook-dir=/home/${NB_USER} \
+/opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
                  --port=8888 \

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -73,7 +73,7 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
-jupyter server --notebook-dir=/home/${NB_USER} \
+/opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
                  --port=8888 \

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -73,7 +73,7 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
-jupyter server --notebook-dir=/home/${NB_USER} \
+/opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
                  --port=8888 \


### PR DESCRIPTION
use full path to jupyter server

Closes https://github.com/StatCan/daaas/issues/805

Have to wait for CVE fix 
# Description

**What your PR adds/fixes/removes**

# Tests / Quality Checks

## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test (e.g. `k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
