### PR TITLE
fix(StatCan/daaas#840): difficulty installing from conda

### DIFF
--- a/docker-bits/∞_CMD.Dockerfile
+++ b/docker-bits/∞_CMD.Dockerfile
@@ -15,7 +15,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/docker-stacks-datascience-notebook/Dockerfile
+++ b/output/docker-stacks-datascience-notebook/Dockerfile
@@ -21,7 +21,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/docker-stacks-datascience-notebook/Rprofile.site
+++ b/output/docker-stacks-datascience-notebook/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/docker-stacks-datascience-notebook/pip.conf
+++ b/output/docker-stacks-datascience-notebook/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
+index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -297,7 +297,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/jupyterlab-cpu/Rprofile.site
+++ b/output/jupyterlab-cpu/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/jupyterlab-cpu/pip.conf
+++ b/output/jupyterlab-cpu/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
+index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -394,7 +394,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/jupyterlab-pytorch/Rprofile.site
+++ b/output/jupyterlab-pytorch/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/jupyterlab-pytorch/pip.conf
+++ b/output/jupyterlab-pytorch/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
+index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -389,7 +389,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/jupyterlab-tensorflow/Rprofile.site
+++ b/output/jupyterlab-tensorflow/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/jupyterlab-tensorflow/pip.conf
+++ b/output/jupyterlab-tensorflow/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
+index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple

--- a/output/remote-desktop/.condarc
+++ b/output/remote-desktop/.condarc
@@ -1,4 +1,4 @@
 channels:
-  - http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote
+  - https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote
 auto_update_conda: false
 show_channel_urls: true

--- a/output/remote-desktop/Rprofile.site
+++ b/output/remote-desktop/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/remote-desktop/pip.conf
+++ b/output/remote-desktop/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
+index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -219,7 +219,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/rstudio/Rprofile.site
+++ b/output/rstudio/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/rstudio/pip.conf
+++ b/output/rstudio/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
+index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple

--- a/resources/common/Rprofile.site
+++ b/resources/common/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/resources/common/pip.conf
+++ b/resources/common/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
+index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple

--- a/resources/remote-desktop/.condarc
+++ b/resources/remote-desktop/.condarc
@@ -1,4 +1,4 @@
 channels:
-  - http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote
+  - https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote
 auto_update_conda: false
 show_channel_urls: true


### PR DESCRIPTION
I've changed the URL `http://jfrog-platform-artifactory-ha.jfrog-system:8081` to `https://jfrog.aaw.cloud.statcan.ca/` everywhere. Fixes StatCan/daaas#840.

I tested this by manually changing the URLs inside a running container on the AAW and this allowed me to install any package, including `opencv`.