### PR TITLE
fix(jupyter-images)Downgrade markupsafe to v2.0.1

### DIFF
--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -48,6 +48,7 @@ RUN pip install --quiet \
       'jupyter-server-proxy==1.6.0' \
       'kubeflow-kale==0.6.1' \
       'jupyterlab_execute_time==2.0.1' \
+      'markupsafe==2.0.1' \
       'git+https://github.com/betatim/vscode-binder' \
     && \
     conda install --quiet --yes \
@@ -105,7 +106,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'bash-language-server' \
       'dockerfile-language-server-nodejs' \
       'javascript-typescript-langserver' \
-      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this 
+      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this
       'unified-language-server' \
       'yaml-language-server@0.18.0' \
     && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -192,6 +192,7 @@ RUN pip install --quiet \
       'jupyter-server-proxy==1.6.0' \
       'kubeflow-kale==0.6.1' \
       'jupyterlab_execute_time==2.0.1' \
+      'markupsafe==2.0.1' \
       'git+https://github.com/betatim/vscode-binder' \
     && \
     conda install --quiet --yes \
@@ -249,7 +250,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'bash-language-server' \
       'dockerfile-language-server-nodejs' \
       'javascript-typescript-langserver' \
-      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this 
+      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this
       'unified-language-server' \
       'yaml-language-server@0.18.0' \
     && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -289,6 +289,7 @@ RUN pip install --quiet \
       'jupyter-server-proxy==1.6.0' \
       'kubeflow-kale==0.6.1' \
       'jupyterlab_execute_time==2.0.1' \
+      'markupsafe==2.0.1' \
       'git+https://github.com/betatim/vscode-binder' \
     && \
     conda install --quiet --yes \
@@ -346,7 +347,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'bash-language-server' \
       'dockerfile-language-server-nodejs' \
       'javascript-typescript-langserver' \
-      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this 
+      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this
       'unified-language-server' \
       'yaml-language-server@0.18.0' \
     && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -284,6 +284,7 @@ RUN pip install --quiet \
       'jupyter-server-proxy==1.6.0' \
       'kubeflow-kale==0.6.1' \
       'jupyterlab_execute_time==2.0.1' \
+      'markupsafe==2.0.1' \
       'git+https://github.com/betatim/vscode-binder' \
     && \
     conda install --quiet --yes \
@@ -341,7 +342,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'bash-language-server' \
       'dockerfile-language-server-nodejs' \
       'javascript-typescript-langserver' \
-      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this 
+      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this
       'unified-language-server' \
       'yaml-language-server@0.18.0' \
     && \


### PR DESCRIPTION
# Description

**What your PR adds/fixes/removes**
Related upstream issue: https://github.com/aws/aws-sam-cli/issues/3661

# Tests / Quality Checks

## Automated Testing/build and deployment
- [x] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [x] Does VS Code open?
- [x] Can you install extensions?

## Code review

- [x] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test (e.g. `k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
