### PR TITLE
Update 3_Kubeflow.Dockerfile

### DIFF
--- a/docker-bits/3_Kubeflow.Dockerfile
+++ b/docker-bits/3_Kubeflow.Dockerfile
@@ -10,6 +10,7 @@ RUN pip3 --no-cache-dir install --quiet \
       fix-permissions /home/$NB_USER
 
 RUN pip3 --no-cache-dir install --quiet \
+      'openpyxl==3.0.9' \ # needed for reading Excel files into Pandas
       'kfp==1.7.2' \
       'kfp-server-api==1.7.1' \
       'ml-metadata==0.27.0' \


### PR DESCRIPTION
Added `openpyxl` since we need that to read Excel files in Pandas. I set it to the latest version number. Was tested on the JupyterLab CPU image March 31 2022.

# Description

**What your PR adds/fixes/removes**

# Tests / Quality Checks

## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test (e.g. `k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
