### PR TITLE
fix(jfrog url): use internal urls

### DIFF
--- a/docker-bits/∞_CMD.Dockerfile
+++ b/docker-bits/∞_CMD.Dockerfile
@@ -15,7 +15,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/docker-stacks-datascience-notebook/Dockerfile
+++ b/output/docker-stacks-datascience-notebook/Dockerfile
@@ -21,7 +21,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/docker-stacks-datascience-notebook/Rprofile.site
+++ b/output/docker-stacks-datascience-notebook/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/docker-stacks-datascience-notebook/pip.conf
+++ b/output/docker-stacks-datascience-notebook/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple
+index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -291,7 +291,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/jupyterlab-cpu/Rprofile.site
+++ b/output/jupyterlab-cpu/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/jupyterlab-cpu/pip.conf
+++ b/output/jupyterlab-cpu/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple
+index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -388,7 +388,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/jupyterlab-pytorch/Rprofile.site
+++ b/output/jupyterlab-pytorch/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/jupyterlab-pytorch/pip.conf
+++ b/output/jupyterlab-pytorch/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple
+index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -383,7 +383,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/jupyterlab-tensorflow/Rprofile.site
+++ b/output/jupyterlab-tensorflow/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/jupyterlab-tensorflow/pip.conf
+++ b/output/jupyterlab-tensorflow/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple
+index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple

--- a/output/remote-desktop/.condarc
+++ b/output/remote-desktop/.condarc
@@ -1,4 +1,4 @@
 channels:
-  - https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote
+  - http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote
 auto_update_conda: false
 show_channel_urls: true

--- a/output/remote-desktop/Rprofile.site
+++ b/output/remote-desktop/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/remote-desktop/pip.conf
+++ b/output/remote-desktop/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple
+index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -212,7 +212,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/rstudio/Rprofile.site
+++ b/output/rstudio/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/rstudio/pip.conf
+++ b/output/rstudio/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple
+index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -349,7 +349,7 @@ COPY Rprofile.site /tmp/Rprofile.site
 RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rprofile.site
 
 # Point conda to Artifactory repository
-RUN conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote --system && \
+RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
     conda config --remove channels conda-forge --system
 
 USER $NB_USER

--- a/output/sas/Rprofile.site
+++ b/output/sas/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/output/sas/pip.conf
+++ b/output/sas/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple
+index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple

--- a/resources/common/Rprofile.site
+++ b/resources/common/Rprofile.site
@@ -1,4 +1,4 @@
 local({
-    r <- list("dev-cran-remote" = "https://jfrog.aaw.cloud.statcan.ca/artifactory/dev-cran-remote/")
+    r <- list("dev-cran-remote" = "http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/dev-cran-remote/")
     options(repos = r)
 })

--- a/resources/common/pip.conf
+++ b/resources/common/pip.conf
@@ -3,4 +3,4 @@ user = true
 
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
-index-url = https://jfrog.aaw.cloud.statcan.ca/artifactory/api/pypi/pypi-remote/simple
+index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple

--- a/resources/remote-desktop/.condarc
+++ b/resources/remote-desktop/.condarc
@@ -1,4 +1,4 @@
 channels:
-  - https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-forge-remote
+  - http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote
 auto_update_conda: false
 show_channel_urls: true


### PR DESCRIPTION
Closes #332 this should fix prod and protected b notebooks
needing to specify the url to install packages

# Description

**What your PR adds/fixes/removes**

# Tests / Quality Checks

## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test (e.g. `k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
