### PR TITLE
add: trino wrapper script

### DIFF
--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -39,8 +39,7 @@ COPY shell_helpers.sh /tmp/shell_helpers.sh
 
 # Install OpenJDK-8
 RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
+    apt-get install -y openjdk-8-jre && \
     apt-get clean && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -60,8 +59,8 @@ RUN curl -LO "${KUBECTL_URL}" \
     && echo "${OH_MY_ZSH_SHA} /tmp/oh-my-zsh-install.sh" | sha256sum -c \
     && echo "oh-my-zsh: ok" \
   && \
-    wget -q "${TRINO_URL}" -O /tmp/trino \
-    && echo ${TRINO_SHA} /tmp/trino | sha256sum -c \
+    wget -q "${TRINO_URL}" -O /tmp/trino-original \
+    && echo ${TRINO_SHA} /tmp/trino-original | sha256sum -c \
     && echo "trinocli: ok" \
-    && chmod +x /tmp/trino \
-    && sudo mv /tmp/trino /usr/local/bin/trino
+    && chmod +x /tmp/trino-original \
+    && sudo mv /tmp/trino-original /usr/local/bin/trino-original

--- a/docker-bits/∞_CMD.Dockerfile
+++ b/docker-bits/∞_CMD.Dockerfile
@@ -4,7 +4,9 @@ USER root
 WORKDIR /home/$NB_USER
 EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
-COPY mc-tenant-wrapper.sh /usr/local/bin/mc 
+COPY mc-tenant-wrapper.sh /usr/local/bin/mc
+COPY trino-wrapper.sh /usr/local/bin/trino
+RUN chmod +x /usr/local/bin/trino
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/docker-stacks-datascience-notebook/Dockerfile
+++ b/output/docker-stacks-datascience-notebook/Dockerfile
@@ -10,7 +10,9 @@ USER root
 WORKDIR /home/$NB_USER
 EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
-COPY mc-tenant-wrapper.sh /usr/local/bin/mc 
+COPY mc-tenant-wrapper.sh /usr/local/bin/mc
+COPY trino-wrapper.sh /usr/local/bin/trino
+RUN chmod +x /usr/local/bin/trino
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/docker-stacks-datascience-notebook/trino-wrapper.sh
+++ b/output/docker-stacks-datascience-notebook/trino-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get token from default service account
+GET_TOKEN="$(kubectl describe secret default-token | grep 'token:' | sed 's/^.*://')"
+
+#todo: Change server when deployed on dev. Placeholder for now
+SERVER=https://trino.example.com
+
+# Trino client pass in server, access token and additional options the user can configures
+# todo: remove user option
+trino-original --server $SERVER --insecure --access-token $GET_TOKEN --user default "$@"

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -108,8 +108,7 @@ COPY shell_helpers.sh /tmp/shell_helpers.sh
 
 # Install OpenJDK-8
 RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
+    apt-get install -y openjdk-8-jre && \
     apt-get clean && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -129,11 +128,11 @@ RUN curl -LO "${KUBECTL_URL}" \
     && echo "${OH_MY_ZSH_SHA} /tmp/oh-my-zsh-install.sh" | sha256sum -c \
     && echo "oh-my-zsh: ok" \
   && \
-    wget -q "${TRINO_URL}" -O /tmp/trino \
-    && echo ${TRINO_SHA} /tmp/trino | sha256sum -c \
+    wget -q "${TRINO_URL}" -O /tmp/trino-original \
+    && echo ${TRINO_SHA} /tmp/trino-original | sha256sum -c \
     && echo "trinocli: ok" \
-    && chmod +x /tmp/trino \
-    && sudo mv /tmp/trino /usr/local/bin/trino
+    && chmod +x /tmp/trino-original \
+    && sudo mv /tmp/trino-original /usr/local/bin/trino-original
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile
@@ -296,7 +295,9 @@ USER root
 WORKDIR /home/$NB_USER
 EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
-COPY mc-tenant-wrapper.sh /usr/local/bin/mc 
+COPY mc-tenant-wrapper.sh /usr/local/bin/mc
+COPY trino-wrapper.sh /usr/local/bin/trino
+RUN chmod +x /usr/local/bin/trino
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/jupyterlab-cpu/trino-wrapper.sh
+++ b/output/jupyterlab-cpu/trino-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get token from default service account
+GET_TOKEN="$(kubectl describe secret default-token | grep 'token:' | sed 's/^.*://')"
+
+#todo: Change server when deployed on dev. Placeholder for now
+SERVER=https://trino.example.com
+
+# Trino client pass in server, access token and additional options the user can configures
+# todo: remove user option
+trino-original --server $SERVER --insecure --access-token $GET_TOKEN --user default "$@"

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -205,8 +205,7 @@ COPY shell_helpers.sh /tmp/shell_helpers.sh
 
 # Install OpenJDK-8
 RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
+    apt-get install -y openjdk-8-jre && \
     apt-get clean && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -226,11 +225,11 @@ RUN curl -LO "${KUBECTL_URL}" \
     && echo "${OH_MY_ZSH_SHA} /tmp/oh-my-zsh-install.sh" | sha256sum -c \
     && echo "oh-my-zsh: ok" \
   && \
-    wget -q "${TRINO_URL}" -O /tmp/trino \
-    && echo ${TRINO_SHA} /tmp/trino | sha256sum -c \
+    wget -q "${TRINO_URL}" -O /tmp/trino-original \
+    && echo ${TRINO_SHA} /tmp/trino-original | sha256sum -c \
     && echo "trinocli: ok" \
-    && chmod +x /tmp/trino \
-    && sudo mv /tmp/trino /usr/local/bin/trino
+    && chmod +x /tmp/trino-original \
+    && sudo mv /tmp/trino-original /usr/local/bin/trino-original
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile
@@ -393,7 +392,9 @@ USER root
 WORKDIR /home/$NB_USER
 EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
-COPY mc-tenant-wrapper.sh /usr/local/bin/mc 
+COPY mc-tenant-wrapper.sh /usr/local/bin/mc
+COPY trino-wrapper.sh /usr/local/bin/trino
+RUN chmod +x /usr/local/bin/trino
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/jupyterlab-pytorch/trino-wrapper.sh
+++ b/output/jupyterlab-pytorch/trino-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get token from default service account
+GET_TOKEN="$(kubectl describe secret default-token | grep 'token:' | sed 's/^.*://')"
+
+#todo: Change server when deployed on dev. Placeholder for now
+SERVER=https://trino.example.com
+
+# Trino client pass in server, access token and additional options the user can configures
+# todo: remove user option
+trino-original --server $SERVER --insecure --access-token $GET_TOKEN --user default "$@"

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -200,8 +200,7 @@ COPY shell_helpers.sh /tmp/shell_helpers.sh
 
 # Install OpenJDK-8
 RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
+    apt-get install -y openjdk-8-jre && \
     apt-get clean && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -221,11 +220,11 @@ RUN curl -LO "${KUBECTL_URL}" \
     && echo "${OH_MY_ZSH_SHA} /tmp/oh-my-zsh-install.sh" | sha256sum -c \
     && echo "oh-my-zsh: ok" \
   && \
-    wget -q "${TRINO_URL}" -O /tmp/trino \
-    && echo ${TRINO_SHA} /tmp/trino | sha256sum -c \
+    wget -q "${TRINO_URL}" -O /tmp/trino-original \
+    && echo ${TRINO_SHA} /tmp/trino-original | sha256sum -c \
     && echo "trinocli: ok" \
-    && chmod +x /tmp/trino \
-    && sudo mv /tmp/trino /usr/local/bin/trino
+    && chmod +x /tmp/trino-original \
+    && sudo mv /tmp/trino-original /usr/local/bin/trino-original
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile
@@ -388,7 +387,9 @@ USER root
 WORKDIR /home/$NB_USER
 EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
-COPY mc-tenant-wrapper.sh /usr/local/bin/mc 
+COPY mc-tenant-wrapper.sh /usr/local/bin/mc
+COPY trino-wrapper.sh /usr/local/bin/trino
+RUN chmod +x /usr/local/bin/trino
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/jupyterlab-tensorflow/trino-wrapper.sh
+++ b/output/jupyterlab-tensorflow/trino-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get token from default service account
+GET_TOKEN="$(kubectl describe secret default-token | grep 'token:' | sed 's/^.*://')"
+
+#todo: Change server when deployed on dev. Placeholder for now
+SERVER=https://trino.example.com
+
+# Trino client pass in server, access token and additional options the user can configures
+# todo: remove user option
+trino-original --server $SERVER --insecure --access-token $GET_TOKEN --user default "$@"

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -110,8 +110,7 @@ COPY shell_helpers.sh /tmp/shell_helpers.sh
 
 # Install OpenJDK-8
 RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
+    apt-get install -y openjdk-8-jre && \
     apt-get clean && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -131,11 +130,11 @@ RUN curl -LO "${KUBECTL_URL}" \
     && echo "${OH_MY_ZSH_SHA} /tmp/oh-my-zsh-install.sh" | sha256sum -c \
     && echo "oh-my-zsh: ok" \
   && \
-    wget -q "${TRINO_URL}" -O /tmp/trino \
-    && echo ${TRINO_SHA} /tmp/trino | sha256sum -c \
+    wget -q "${TRINO_URL}" -O /tmp/trino-original \
+    && echo ${TRINO_SHA} /tmp/trino-original | sha256sum -c \
     && echo "trinocli: ok" \
-    && chmod +x /tmp/trino \
-    && sudo mv /tmp/trino /usr/local/bin/trino
+    && chmod +x /tmp/trino-original \
+    && sudo mv /tmp/trino-original /usr/local/bin/trino-original
 
 ###############################
 ###  docker-bits/6_remote-desktop.Dockerfile

--- a/output/remote-desktop/trino-wrapper.sh
+++ b/output/remote-desktop/trino-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get token from default service account
+GET_TOKEN="$(kubectl describe secret default-token | grep 'token:' | sed 's/^.*://')"
+
+#todo: Change server when deployed on dev. Placeholder for now
+SERVER=https://trino.example.com
+
+# Trino client pass in server, access token and additional options the user can configures
+# todo: remove user option
+trino-original --server $SERVER --insecure --access-token $GET_TOKEN --user default "$@"

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -108,8 +108,7 @@ COPY shell_helpers.sh /tmp/shell_helpers.sh
 
 # Install OpenJDK-8
 RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
+    apt-get install -y openjdk-8-jre && \
     apt-get clean && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -129,11 +128,11 @@ RUN curl -LO "${KUBECTL_URL}" \
     && echo "${OH_MY_ZSH_SHA} /tmp/oh-my-zsh-install.sh" | sha256sum -c \
     && echo "oh-my-zsh: ok" \
   && \
-    wget -q "${TRINO_URL}" -O /tmp/trino \
-    && echo ${TRINO_SHA} /tmp/trino | sha256sum -c \
+    wget -q "${TRINO_URL}" -O /tmp/trino-original \
+    && echo ${TRINO_SHA} /tmp/trino-original | sha256sum -c \
     && echo "trinocli: ok" \
-    && chmod +x /tmp/trino \
-    && sudo mv /tmp/trino /usr/local/bin/trino
+    && chmod +x /tmp/trino-original \
+    && sudo mv /tmp/trino-original /usr/local/bin/trino-original
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile
@@ -217,7 +216,9 @@ USER root
 WORKDIR /home/$NB_USER
 EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
-COPY mc-tenant-wrapper.sh /usr/local/bin/mc 
+COPY mc-tenant-wrapper.sh /usr/local/bin/mc
+COPY trino-wrapper.sh /usr/local/bin/trino
+RUN chmod +x /usr/local/bin/trino
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/rstudio/trino-wrapper.sh
+++ b/output/rstudio/trino-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get token from default service account
+GET_TOKEN="$(kubectl describe secret default-token | grep 'token:' | sed 's/^.*://')"
+
+#todo: Change server when deployed on dev. Placeholder for now
+SERVER=https://trino.example.com
+
+# Trino client pass in server, access token and additional options the user can configures
+# todo: remove user option
+trino-original --server $SERVER --insecure --access-token $GET_TOKEN --user default "$@"

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -108,8 +108,7 @@ COPY shell_helpers.sh /tmp/shell_helpers.sh
 
 # Install OpenJDK-8
 RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
+    apt-get install -y openjdk-8-jre && \
     apt-get clean && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -129,11 +128,11 @@ RUN curl -LO "${KUBECTL_URL}" \
     && echo "${OH_MY_ZSH_SHA} /tmp/oh-my-zsh-install.sh" | sha256sum -c \
     && echo "oh-my-zsh: ok" \
   && \
-    wget -q "${TRINO_URL}" -O /tmp/trino \
-    && echo ${TRINO_SHA} /tmp/trino | sha256sum -c \
+    wget -q "${TRINO_URL}" -O /tmp/trino-original \
+    && echo ${TRINO_SHA} /tmp/trino-original | sha256sum -c \
     && echo "trinocli: ok" \
-    && chmod +x /tmp/trino \
-    && sudo mv /tmp/trino /usr/local/bin/trino
+    && chmod +x /tmp/trino-original \
+    && sudo mv /tmp/trino-original /usr/local/bin/trino-original
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile
@@ -354,7 +353,9 @@ USER root
 WORKDIR /home/$NB_USER
 EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
-COPY mc-tenant-wrapper.sh /usr/local/bin/mc 
+COPY mc-tenant-wrapper.sh /usr/local/bin/mc
+COPY trino-wrapper.sh /usr/local/bin/trino
+RUN chmod +x /usr/local/bin/trino
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/sas/trino-wrapper.sh
+++ b/output/sas/trino-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get token from default service account
+GET_TOKEN="$(kubectl describe secret default-token | grep 'token:' | sed 's/^.*://')"
+
+#todo: Change server when deployed on dev. Placeholder for now
+SERVER=https://trino.example.com
+
+# Trino client pass in server, access token and additional options the user can configures
+# todo: remove user option
+trino-original --server $SERVER --insecure --access-token $GET_TOKEN --user default "$@"

--- a/resources/common/trino-wrapper.sh
+++ b/resources/common/trino-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get token from default service account
+GET_TOKEN="$(kubectl describe secret default-token | grep 'token:' | sed 's/^.*://')"
+
+#todo: Change server when deployed on dev. Placeholder for now
+SERVER=https://trino.example.com
+
+# Trino client pass in server, access token and additional options the user can configures
+# todo: remove user option
+trino-original --server $SERVER --insecure --access-token $GET_TOKEN --user default "$@"


### PR DESCRIPTION
# Description
closes https://github.com/StatCan/daaas/issues/930
**What your PR adds/fixes/removes**

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
