### PR TITLE
debug(nginx.conf): hypothesis testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 .venv
 .ipynb_checkpoints/
 .idea
+
+.vscode/

--- a/README.md
+++ b/README.md
@@ -262,3 +262,4 @@ would add two layers, each about 1GB (2GB total).
 ## Troubleshooting
 If running using a VM and RStudio image was built successfully but is not opening correctly on localhost (error 5000 page), change your CPU allocation in your Linux VM settings to >= 3. You can also use your VM's system monitor to examine if all CPUs are 100% being used as your container is running. If so, increase CPU allocation. 
 This was tested on Linux Ubuntu 20.04 virtual machine.
+hello world

--- a/output/remote-desktop/nginx.conf
+++ b/output/remote-desktop/nginx.conf
@@ -22,10 +22,10 @@ http {
     client_body_timeout 300s;
     client_header_timeout 120s;
 
-    proxy_connect_timeout 600;
-    proxy_send_timeout 600;
-    proxy_read_timeout 600;
-    send_timeout 600;
+    proxy_connect_timeout 180;
+    proxy_send_timeout 180;
+    proxy_read_timeout 180;
+    send_timeout 180;
 
 
     upstream vnc_proxy {
@@ -114,7 +114,7 @@ http {
             proxy_set_header Connection "upgrade";
 
             # VNC connection timeout
-            proxy_read_timeout 61s;
+            proxy_read_timeout 120s;
 
             # Disable cache
             proxy_buffering off;

--- a/resources/remote-desktop/nginx.conf
+++ b/resources/remote-desktop/nginx.conf
@@ -22,10 +22,10 @@ http {
     client_body_timeout 300s;
     client_header_timeout 120s;
 
-    proxy_connect_timeout 600;
-    proxy_send_timeout 600;
-    proxy_read_timeout 600;
-    send_timeout 600;
+    proxy_connect_timeout 180;
+    proxy_send_timeout 180;
+    proxy_read_timeout 180;
+    send_timeout 180;
 
 
     upstream vnc_proxy {
@@ -114,7 +114,7 @@ http {
             proxy_set_header Connection "upgrade";
 
             # VNC connection timeout
-            proxy_read_timeout 61s;
+            proxy_read_timeout 120s;
 
             # Disable cache
             proxy_buffering off;


### PR DESCRIPTION
- proxy_read_timeout of 120s
- http timeouts of 180s

# Description

**What your PR adds/fixes/removes**

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
