### PR TITLE
Update OpenM++ installation to support multiple simultaneous versions

### DIFF
--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -272,24 +272,24 @@ RUN /bin/bash $RESOURCES_PATH/pspp.sh \
 COPY minio-icon.png $RESOURCES_PATH/minio-icon.png
 COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 
-# OpenM++ Install
-ENV OMPP_VERSION="1.9.8"
-ENV OMPP_PKG_DATE="20220323"
-ARG SHA256ompp=9882798fe2738729cac14d8a62cac8c285fca44e12b8b575ec0d0e6b03ab7a02
+# Install OpenM++
+ENV OMPP_VERSION="1.9.9"
+# IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
+ENV OMPP_PKG_DATE="20220505"
+ARG SHA256ompp=479a9a79356a4dd331bcc6cf00110d40feecd6c37f004156f9b4739db2e8ae90
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100
 ENV OMPP_UID=$NB_UID
 ENV OMPP_GID=$NB_GID
-# Where OpenM++ should look for files when building models
-ENV OM_ROOT=/opt/openmpp
 # OpenM++ expects sqlite to be installed (not just libsqlite)
-RUN apt-get install --yes sqlite3
-RUN wget https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_ubuntu_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
+RUN apt-get install --yes sqlite3 \
+    && wget https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_ubuntu_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
     && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/ompp.tar.gz -C /tmp/ \
-    && mv /tmp/openmpp_ubuntu_${OMPP_PKG_DATE} $OM_ROOT \
-    && chown -R $NB_UID:$NB_GID $OM_ROOT
+    && mkdir /opt/openmpp \
+    && mv /tmp/openmpp_ubuntu_${OMPP_PKG_DATE} /opt/openmpp/${OMPP_VERSION} \
+    && chown -R $NB_UID:$NB_GID /opt/openmpp
 # Copy the desktop icon into place for the web UI
 COPY openmpp.png $RESOURCES_PATH/openmpp.png
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -414,24 +414,24 @@ RUN /bin/bash $RESOURCES_PATH/pspp.sh \
 COPY minio-icon.png $RESOURCES_PATH/minio-icon.png
 COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 
-# OpenM++ Install
-ENV OMPP_VERSION="1.9.8"
-ENV OMPP_PKG_DATE="20220323"
-ARG SHA256ompp=9882798fe2738729cac14d8a62cac8c285fca44e12b8b575ec0d0e6b03ab7a02
+# Install OpenM++
+ENV OMPP_VERSION="1.9.9"
+# IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
+ENV OMPP_PKG_DATE="20220505"
+ARG SHA256ompp=479a9a79356a4dd331bcc6cf00110d40feecd6c37f004156f9b4739db2e8ae90
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100
 ENV OMPP_UID=$NB_UID
 ENV OMPP_GID=$NB_GID
-# Where OpenM++ should look for files when building models
-ENV OM_ROOT=/opt/openmpp
 # OpenM++ expects sqlite to be installed (not just libsqlite)
-RUN apt-get install --yes sqlite3
-RUN wget https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_ubuntu_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
+RUN apt-get install --yes sqlite3 \
+    && wget https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_ubuntu_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
     && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/ompp.tar.gz -C /tmp/ \
-    && mv /tmp/openmpp_ubuntu_${OMPP_PKG_DATE} $OM_ROOT \
-    && chown -R $NB_UID:$NB_GID $OM_ROOT
+    && mkdir /opt/openmpp \
+    && mv /tmp/openmpp_ubuntu_${OMPP_PKG_DATE} /opt/openmpp/${OMPP_VERSION} \
+    && chown -R $NB_UID:$NB_GID /opt/openmpp
 # Copy the desktop icon into place for the web UI
 COPY openmpp.png $RESOURCES_PATH/openmpp.png
 

--- a/output/remote-desktop/desktop-files/openmpp.desktop
+++ b/output/remote-desktop/desktop-files/openmpp.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=OpenM++
-Exec=/opt/openmpp/bin/ompp_ui_linux.sh
+Exec=/opt/openmpp/1.9.9/bin/ompp_ui_linux.sh
 Icon=/resources/openmpp.png
 Terminal=false
 Categories=Development;

--- a/resources/remote-desktop/desktop-files/openmpp.desktop
+++ b/resources/remote-desktop/desktop-files/openmpp.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=OpenM++
-Exec=/opt/openmpp/bin/ompp_ui_linux.sh
+Exec=/opt/openmpp/1.9.9/bin/ompp_ui_linux.sh
 Icon=/resources/openmpp.png
 Terminal=false
 Categories=Development;


### PR DESCRIPTION
# Description

Add super for multiple user managed OpenM++ versions to be installed side by side and enable testing of model development and results.

Closes #353 

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
