### PR TITLE
Add missing .profile

### DIFF
--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -117,5 +117,8 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
 # Solarized Theme and Cell Execution Time
 COPY jupyterlab-overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json
 
+# .profile needed to source .bashrc
+COPY ./resources/common/.profile ~/.profile
+
 ENV DEFAULT_JUPYTER_URL=/lab
 ENV GIT_EXAMPLE_NOTEBOOKS=https://github.com/StatCan/aaw-contrib-jupyter-notebooks

--- a/resources/common/.profile
+++ b/resources/common/.profile
@@ -1,0 +1,6 @@
+if [ -n "$BASH_VERSION" ]; then
+    # include .bashrc if it exists
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi


### PR DESCRIPTION
# Description

Addresses .bashrc not being sourced at startup, see https://github.com/StatCan/aaw-kubeflow-containers/issues/364.