### PR TITLE
chore(allowedlist): include CVE-2022-34749 to whitelist

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -2,3 +2,4 @@ general:
   vulnerabilities:
     - CVE-2021-23334 # static-eval - was deemed not a vulnerability
     - CVE-2020-1747 # see https://github.com/StatCan/aaw-kubeflow-containers/pull/296#issuecomment-939077876
+    - CVE-2022-34749 # see https://github.com/StatCan/aaw-kubeflow-containers/issues/374


### PR DESCRIPTION
# Description

See comment on https://github.com/StatCan/daaas-private/issues/16
Closes StatCan/daaas-private#16 

# Tests / Quality Checks
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?

## Code review

- [x] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [x] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
