### PR TITLE
fix: persist code-server settings and extensions

### DIFF
--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -18,7 +18,7 @@ ARG VSCODE_URL=https://github.com/coder/code-server/releases/download/v${VSCODE_
 USER root
 
 ENV CS_DISABLE_FILE_DOWNLOADS=1
-ENV XDG_DATA_HOME=$HOME/.local/share
+ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 
 RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
@@ -28,7 +28,8 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
     && dpkg -i ./vscode.deb \
     && rm ./vscode.deb \
     && rm -f /etc/apt/sources.list.d/vscode.list \
-    && mkdir -p $XDG_DATA_HOME/code-server/extensions 
+    && mkdir -p $HOME/.local/share \
+    && mkdir -p $XDG_DATA_HOME/code-server/extensions
 
 # Fix for VSCode extensions and CORS
 # Languagepacks.json needs to exist for code-server to recognize the languagepack

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -44,7 +44,7 @@ RUN VS_PYTHON_VERSION="2021.5.829140558" && \
     rm ms-python-release.vsix && \
     code-server --install-extension ikuyadeu.r@1.6.6 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
-    code-server --install-extension quarto-1.51.0.vsix && \
+    code-server --install-extension quarto.quarto@1.51.0 && \
     fix-permissions $XDG_DATA_HOME
 
 # Default environment

--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -84,6 +84,15 @@ export TRINO_PASSWORD="$(kubectl get secret trino-auth -n $NB_NAMESPACE --templa
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
+VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+if [-f "$VS_CODE_PRESISTED" ]; then
+    cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
+else
+    cp vscode-overrides.json "$VS_CODE_SETTINGS"
+fi
+
+
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -96,7 +105,5 @@ printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS=${XDG_DATA_HOME}/code-server/Machine/settings.json
-if [! -f "$VS_CODE_SETTINGS" ]; then
-    cp vscode-overrides.json "$VS_CODE_SETTINGS"
-fi
+VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -197,7 +197,7 @@ RUN VS_PYTHON_VERSION="2021.5.829140558" && \
     rm ms-python-release.vsix && \
     code-server --install-extension ikuyadeu.r@1.6.6 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
-    code-server --install-extension quarto-1.51.0.vsix && \
+    code-server --install-extension quarto.quarto@1.51.0 && \
     fix-permissions $XDG_DATA_HOME
 
 # Default environment

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -171,7 +171,7 @@ ARG VSCODE_URL=https://github.com/coder/code-server/releases/download/v${VSCODE_
 USER root
 
 ENV CS_DISABLE_FILE_DOWNLOADS=1
-ENV XDG_DATA_HOME=$HOME/.local/share
+ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 
 RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
@@ -181,7 +181,8 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
     && dpkg -i ./vscode.deb \
     && rm ./vscode.deb \
     && rm -f /etc/apt/sources.list.d/vscode.list \
-    && mkdir -p $XDG_DATA_HOME/code-server/extensions 
+    && mkdir -p $HOME/.local/share \
+    && mkdir -p $XDG_DATA_HOME/code-server/extensions
 
 # Fix for VSCode extensions and CORS
 # Languagepacks.json needs to exist for code-server to recognize the languagepack

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -197,7 +197,7 @@ RUN VS_PYTHON_VERSION="2021.5.829140558" && \
     rm ms-python-release.vsix && \
     code-server --install-extension ikuyadeu.r@1.6.6 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
-    code-server --install-extension Quarto@1.51.0 && \
+    code-server --install-extension quarto-1.51.0.vsix && \
     fix-permissions $XDG_DATA_HOME
 
 # Default environment

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -84,6 +84,15 @@ export TRINO_PASSWORD="$(kubectl get secret trino-auth -n $NB_NAMESPACE --templa
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
+VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+if [-f "$VS_CODE_PRESISTED" ]; then
+    cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
+else
+    cp vscode-overrides.json "$VS_CODE_SETTINGS"
+fi
+
+
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -96,7 +105,5 @@ printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS=${XDG_DATA_HOME}/code-server/Machine/settings.json
-if [! -f "$VS_CODE_SETTINGS" ]; then
-    cp vscode-overrides.json "$VS_CODE_SETTINGS"
-fi
+VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -255,7 +255,7 @@ ARG VSCODE_URL=https://github.com/coder/code-server/releases/download/v${VSCODE_
 USER root
 
 ENV CS_DISABLE_FILE_DOWNLOADS=1
-ENV XDG_DATA_HOME=$HOME/.local/share
+ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 
 RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
@@ -265,7 +265,8 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
     && dpkg -i ./vscode.deb \
     && rm ./vscode.deb \
     && rm -f /etc/apt/sources.list.d/vscode.list \
-    && mkdir -p $XDG_DATA_HOME/code-server/extensions 
+    && mkdir -p $HOME/.local/share \
+    && mkdir -p $XDG_DATA_HOME/code-server/extensions
 
 # Fix for VSCode extensions and CORS
 # Languagepacks.json needs to exist for code-server to recognize the languagepack

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -281,7 +281,7 @@ RUN VS_PYTHON_VERSION="2021.5.829140558" && \
     rm ms-python-release.vsix && \
     code-server --install-extension ikuyadeu.r@1.6.6 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
-    code-server --install-extension Quarto@1.51.0 && \
+    code-server --install-extension quarto-1.51.0.vsix && \
     fix-permissions $XDG_DATA_HOME
 
 # Default environment

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -281,7 +281,7 @@ RUN VS_PYTHON_VERSION="2021.5.829140558" && \
     rm ms-python-release.vsix && \
     code-server --install-extension ikuyadeu.r@1.6.6 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
-    code-server --install-extension quarto-1.51.0.vsix && \
+    code-server --install-extension quarto.quarto@1.51.0 && \
     fix-permissions $XDG_DATA_HOME
 
 # Default environment

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -84,6 +84,15 @@ export TRINO_PASSWORD="$(kubectl get secret trino-auth -n $NB_NAMESPACE --templa
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
+VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+if [-f "$VS_CODE_PRESISTED" ]; then
+    cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
+else
+    cp vscode-overrides.json "$VS_CODE_SETTINGS"
+fi
+
+
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -96,7 +105,5 @@ printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS=${XDG_DATA_HOME}/code-server/Machine/settings.json
-if [! -f "$VS_CODE_SETTINGS" ]; then
-    cp vscode-overrides.json "$VS_CODE_SETTINGS"
-fi
+VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -290,7 +290,7 @@ RUN VS_PYTHON_VERSION="2021.5.829140558" && \
     rm ms-python-release.vsix && \
     code-server --install-extension ikuyadeu.r@1.6.6 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
-    code-server --install-extension Quarto@1.51.0 && \
+    code-server --install-extension quarto-1.51.0.vsix && \
     fix-permissions $XDG_DATA_HOME
 
 # Default environment

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -290,7 +290,7 @@ RUN VS_PYTHON_VERSION="2021.5.829140558" && \
     rm ms-python-release.vsix && \
     code-server --install-extension ikuyadeu.r@1.6.6 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
-    code-server --install-extension quarto-1.51.0.vsix && \
+    code-server --install-extension quarto.quarto@1.51.0 && \
     fix-permissions $XDG_DATA_HOME
 
 # Default environment

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -264,7 +264,7 @@ ARG VSCODE_URL=https://github.com/coder/code-server/releases/download/v${VSCODE_
 USER root
 
 ENV CS_DISABLE_FILE_DOWNLOADS=1
-ENV XDG_DATA_HOME=$HOME/.local/share
+ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 
 RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
@@ -274,7 +274,8 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
     && dpkg -i ./vscode.deb \
     && rm ./vscode.deb \
     && rm -f /etc/apt/sources.list.d/vscode.list \
-    && mkdir -p $XDG_DATA_HOME/code-server/extensions 
+    && mkdir -p $HOME/.local/share \
+    && mkdir -p $XDG_DATA_HOME/code-server/extensions
 
 # Fix for VSCode extensions and CORS
 # Languagepacks.json needs to exist for code-server to recognize the languagepack

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -84,6 +84,15 @@ export TRINO_PASSWORD="$(kubectl get secret trino-auth -n $NB_NAMESPACE --templa
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
+VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+if [-f "$VS_CODE_PRESISTED" ]; then
+    cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
+else
+    cp vscode-overrides.json "$VS_CODE_SETTINGS"
+fi
+
+
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -96,7 +105,5 @@ printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS=${XDG_DATA_HOME}/code-server/Machine/settings.json
-if [! -f "$VS_CODE_SETTINGS" ]; then
-    cp vscode-overrides.json "$VS_CODE_SETTINGS"
-fi
+VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -84,6 +84,15 @@ export TRINO_PASSWORD="$(kubectl get secret trino-auth -n $NB_NAMESPACE --templa
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
+VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+if [-f "$VS_CODE_PRESISTED" ]; then
+    cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
+else
+    cp vscode-overrides.json "$VS_CODE_SETTINGS"
+fi
+
+
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -96,7 +105,5 @@ printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS=${XDG_DATA_HOME}/code-server/Machine/settings.json
-if [! -f "$VS_CODE_SETTINGS" ]; then
-    cp vscode-overrides.json "$VS_CODE_SETTINGS"
-fi
+VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -84,6 +84,15 @@ export TRINO_PASSWORD="$(kubectl get secret trino-auth -n $NB_NAMESPACE --templa
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
+VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+if [-f "$VS_CODE_PRESISTED" ]; then
+    cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
+else
+    cp vscode-overrides.json "$VS_CODE_SETTINGS"
+fi
+
+
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -96,7 +105,5 @@ printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS=${XDG_DATA_HOME}/code-server/Machine/settings.json
-if [! -f "$VS_CODE_SETTINGS" ]; then
-    cp vscode-overrides.json "$VS_CODE_SETTINGS"
-fi
+VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -192,7 +192,7 @@ RUN VS_PYTHON_VERSION="2021.5.829140558" && \
     rm ms-python-release.vsix && \
     code-server --install-extension ikuyadeu.r@1.6.6 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
-    code-server --install-extension quarto-1.51.0.vsix && \
+    code-server --install-extension quarto.quarto@1.51.0 && \
     fix-permissions $XDG_DATA_HOME
 
 # Default environment

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -166,7 +166,7 @@ ARG VSCODE_URL=https://github.com/coder/code-server/releases/download/v${VSCODE_
 USER root
 
 ENV CS_DISABLE_FILE_DOWNLOADS=1
-ENV XDG_DATA_HOME=$HOME/.local/share
+ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 
 RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
@@ -176,7 +176,8 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
     && dpkg -i ./vscode.deb \
     && rm ./vscode.deb \
     && rm -f /etc/apt/sources.list.d/vscode.list \
-    && mkdir -p $XDG_DATA_HOME/code-server/extensions 
+    && mkdir -p $HOME/.local/share \
+    && mkdir -p $XDG_DATA_HOME/code-server/extensions
 
 # Fix for VSCode extensions and CORS
 # Languagepacks.json needs to exist for code-server to recognize the languagepack

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -192,7 +192,7 @@ RUN VS_PYTHON_VERSION="2021.5.829140558" && \
     rm ms-python-release.vsix && \
     code-server --install-extension ikuyadeu.r@1.6.6 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
-    code-server --install-extension Quarto@1.51.0 && \
+    code-server --install-extension quarto-1.51.0.vsix && \
     fix-permissions $XDG_DATA_HOME
 
 # Default environment

--- a/output/sas/start-custom.sh
+++ b/output/sas/start-custom.sh
@@ -84,6 +84,15 @@ export TRINO_PASSWORD="$(kubectl get secret trino-auth -n $NB_NAMESPACE --templa
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
+VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+if [-f "$VS_CODE_PRESISTED" ]; then
+    cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
+else
+    cp vscode-overrides.json "$VS_CODE_SETTINGS"
+fi
+
+
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -96,7 +105,5 @@ printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS=${XDG_DATA_HOME}/code-server/Machine/settings.json
-if [! -f "$VS_CODE_SETTINGS" ]; then
-    cp vscode-overrides.json "$VS_CODE_SETTINGS"
-fi
+VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -84,6 +84,15 @@ export TRINO_PASSWORD="$(kubectl get secret trino-auth -n $NB_NAMESPACE --templa
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
+VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+if [-f "$VS_CODE_PRESISTED" ]; then
+    cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
+else
+    cp vscode-overrides.json "$VS_CODE_SETTINGS"
+fi
+
+
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
@@ -96,7 +105,5 @@ printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS=${XDG_DATA_HOME}/code-server/Machine/settings.json
-if [! -f "$VS_CODE_SETTINGS" ]; then
-    cp vscode-overrides.json "$VS_CODE_SETTINGS"
-fi
+VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST


### PR DESCRIPTION
# Description

**What your PR adds/fixes/removes**

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
