### PR TITLE
add: enable xcmd option in sas studio

### DIFF
--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -93,3 +93,6 @@ ENV DEFAULT_JUPYTER_URL=/lab
 
 COPY G-CONFID107003ELNX6494M7/ /usr/local/SASHome/gensys/G-CONFID107003ELNX6494M7/
 COPY sasv9_local.cfg /usr/local/SASHome/SASFoundation/9.4/
+
+# Enable X command on SAS Studio
+COPY spawner_usermods.sh /usr/local/SASHome/studioconfig/spawner/

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -369,6 +369,9 @@ ENV DEFAULT_JUPYTER_URL=/lab
 COPY G-CONFID107003ELNX6494M7/ /usr/local/SASHome/gensys/G-CONFID107003ELNX6494M7/
 COPY sasv9_local.cfg /usr/local/SASHome/SASFoundation/9.4/
 
+# Enable X command on SAS Studio
+COPY spawner_usermods.sh /usr/local/SASHome/studioconfig/spawner/
+
 ###############################
 ###  docker-bits/7_remove_vulnerabilities.Dockerfile
 ###############################

--- a/output/sas/spawner_usermods.sh
+++ b/output/sas/spawner_usermods.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -p
+#
+# spawner_usermods.sh
+#
+# This script extends spawner.sh  Add local environment variables
+# to this file so they will be preserved.
+#
+
+# These options can be extended as needed.
+
+# The following section pertains to establishing JREOPTIONS for use by the
+# Spawner. These options are not enabled by default but are present here to
+# allow for customer activation.
+
+# JREOPTIONS will be processed and passed directly to the Object Spawner if active
+JREOPTIONS=
+
+# The following options are passed to the Object Spawner. Note, they must be
+# valid options.
+USERMODS="$JREOPTIONS -allowxcmd"

--- a/resources/sas/spawner_usermods.sh
+++ b/resources/sas/spawner_usermods.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -p
+#
+# spawner_usermods.sh
+#
+# This script extends spawner.sh  Add local environment variables
+# to this file so they will be preserved.
+#
+
+# These options can be extended as needed.
+
+# The following section pertains to establishing JREOPTIONS for use by the
+# Spawner. These options are not enabled by default but are present here to
+# allow for customer activation.
+
+# JREOPTIONS will be processed and passed directly to the Object Spawner if active
+JREOPTIONS=
+
+# The following options are passed to the Object Spawner. Note, they must be
+# valid options.
+USERMODS="$JREOPTIONS -allowxcmd"


### PR DESCRIPTION
# Description

**What your PR adds/fixes/removes**
closes https://github.com/StatCan/daaas/issues/1402

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
