### PR TITLE
update: vscode settings.json path

### DIFF
--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -103,8 +103,8 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
+    npm i -g bash-language-server && \
     jlpm add --dev \
-      'bash-language-server' \
       'dockerfile-language-server-nodejs' \
       'javascript-typescript-langserver' \
       #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -103,13 +103,14 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
-    npm i -g bash-language-server && \
-    jlpm add --dev \
-      'dockerfile-language-server-nodejs' \
-      'javascript-typescript-langserver' \
-      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this
-      'unified-language-server' \
-      'yaml-language-server@0.18.0' \
+    npm i -g bash-language-server  && \
+    dockerfile-language-server-nodejs &&  \
+    javascript-typescript-langserver && \
+    unified-language-server && \
+    yaml-language-server@0.18.0  && \
+    conda clean --all -f -y && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER  \
     && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -103,11 +103,12 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
-    npm i -g bash-language-server  && \
-    dockerfile-language-server-nodejs &&  \
-    javascript-typescript-langserver && \
-    unified-language-server && \
-    yaml-language-server@0.18.0  && \
+    npm i -g \
+    'bash-language-server'  \
+    'dockerfile-language-server-nodejs' \
+    'javascript-typescript-langserver' \
+    'unified-language-server' \
+    'yaml-language-server@0.18.0'  && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER  \

--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -82,9 +82,9 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
-
+mkdir -p vscode-settings
 VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
-VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/vscode-settings/share/code-server/Machine/settings.json
 if [-f "$VS_CODE_PRESISTED" ]; then
     cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
 else
@@ -104,5 +104,5 @@ fi
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_SETTINGS_PERSIST=$HOME/vscode-settings/share/code-server/Machine/settings.json
 cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -256,11 +256,12 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
-    npm i -g bash-language-server  && \
-    dockerfile-language-server-nodejs &&  \
-    javascript-typescript-langserver && \
-    unified-language-server && \
-    yaml-language-server@0.18.0  && \
+    npm i -g \
+    'bash-language-server'  \
+    'dockerfile-language-server-nodejs' \
+    'javascript-typescript-langserver' \
+    'unified-language-server' \
+    'yaml-language-server@0.18.0'  && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER  \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -256,13 +256,14 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
-    npm i -g bash-language-server && \
-    jlpm add --dev \
-      'dockerfile-language-server-nodejs' \
-      'javascript-typescript-langserver' \
-      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this
-      'unified-language-server' \
-      'yaml-language-server@0.18.0' \
+    npm i -g bash-language-server  && \
+    dockerfile-language-server-nodejs &&  \
+    javascript-typescript-langserver && \
+    unified-language-server && \
+    yaml-language-server@0.18.0  && \
+    conda clean --all -f -y && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER  \
     && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -256,8 +256,8 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
+    npm i -g bash-language-server && \
     jlpm add --dev \
-      'bash-language-server' \
       'dockerfile-language-server-nodejs' \
       'javascript-typescript-langserver' \
       #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -82,9 +82,9 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
-
+mkdir -p vscode-settings
 VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
-VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/vscode-settings/share/code-server/Machine/settings.json
 if [-f "$VS_CODE_PRESISTED" ]; then
     cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
 else
@@ -104,5 +104,5 @@ fi
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_SETTINGS_PERSIST=$HOME/vscode-settings/share/code-server/Machine/settings.json
 cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -340,11 +340,12 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
-    npm i -g bash-language-server  && \
-    dockerfile-language-server-nodejs &&  \
-    javascript-typescript-langserver && \
-    unified-language-server && \
-    yaml-language-server@0.18.0  && \
+    npm i -g \
+    'bash-language-server'  \
+    'dockerfile-language-server-nodejs' \
+    'javascript-typescript-langserver' \
+    'unified-language-server' \
+    'yaml-language-server@0.18.0'  && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER  \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -340,13 +340,14 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
-    npm i -g bash-language-server && \
-    jlpm add --dev \
-      'dockerfile-language-server-nodejs' \
-      'javascript-typescript-langserver' \
-      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this
-      'unified-language-server' \
-      'yaml-language-server@0.18.0' \
+    npm i -g bash-language-server  && \
+    dockerfile-language-server-nodejs &&  \
+    javascript-typescript-langserver && \
+    unified-language-server && \
+    yaml-language-server@0.18.0  && \
+    conda clean --all -f -y && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER  \
     && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -340,8 +340,8 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
+    npm i -g bash-language-server && \
     jlpm add --dev \
-      'bash-language-server' \
       'dockerfile-language-server-nodejs' \
       'javascript-typescript-langserver' \
       #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -82,9 +82,9 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
-
+mkdir -p vscode-settings
 VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
-VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/vscode-settings/share/code-server/Machine/settings.json
 if [-f "$VS_CODE_PRESISTED" ]; then
     cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
 else
@@ -104,5 +104,5 @@ fi
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_SETTINGS_PERSIST=$HOME/vscode-settings/share/code-server/Machine/settings.json
 cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -349,13 +349,14 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
-    npm i -g bash-language-server && \
-    jlpm add --dev \
-      'dockerfile-language-server-nodejs' \
-      'javascript-typescript-langserver' \
-      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this
-      'unified-language-server' \
-      'yaml-language-server@0.18.0' \
+    npm i -g bash-language-server  && \
+    dockerfile-language-server-nodejs &&  \
+    javascript-typescript-langserver && \
+    unified-language-server && \
+    yaml-language-server@0.18.0  && \
+    conda clean --all -f -y && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER  \
     && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -349,8 +349,8 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
+    npm i -g bash-language-server && \
     jlpm add --dev \
-      'bash-language-server' \
       'dockerfile-language-server-nodejs' \
       'javascript-typescript-langserver' \
       #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -349,11 +349,12 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
-    npm i -g bash-language-server  && \
-    dockerfile-language-server-nodejs &&  \
-    javascript-typescript-langserver && \
-    unified-language-server && \
-    yaml-language-server@0.18.0  && \
+    npm i -g \
+    'bash-language-server'  \
+    'dockerfile-language-server-nodejs' \
+    'javascript-typescript-langserver' \
+    'unified-language-server' \
+    'yaml-language-server@0.18.0'  && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER  \

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -82,9 +82,9 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
-
+mkdir -p vscode-settings
 VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
-VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/vscode-settings/share/code-server/Machine/settings.json
 if [-f "$VS_CODE_PRESISTED" ]; then
     cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
 else
@@ -104,5 +104,5 @@ fi
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_SETTINGS_PERSIST=$HOME/vscode-settings/share/code-server/Machine/settings.json
 cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -82,9 +82,9 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
-
+mkdir -p vscode-settings
 VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
-VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/vscode-settings/share/code-server/Machine/settings.json
 if [-f "$VS_CODE_PRESISTED" ]; then
     cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
 else
@@ -104,5 +104,5 @@ fi
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_SETTINGS_PERSIST=$HOME/vscode-settings/share/code-server/Machine/settings.json
 cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -82,9 +82,9 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
-
+mkdir -p vscode-settings
 VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
-VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/vscode-settings/share/code-server/Machine/settings.json
 if [-f "$VS_CODE_PRESISTED" ]; then
     cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
 else
@@ -104,5 +104,5 @@ fi
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_SETTINGS_PERSIST=$HOME/vscode-settings/share/code-server/Machine/settings.json
 cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -251,8 +251,8 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
+    npm i -g bash-language-server && \
     jlpm add --dev \
-      'bash-language-server' \
       'dockerfile-language-server-nodejs' \
       'javascript-typescript-langserver' \
       #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -251,13 +251,14 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
-    npm i -g bash-language-server && \
-    jlpm add --dev \
-      'dockerfile-language-server-nodejs' \
-      'javascript-typescript-langserver' \
-      #'sql-language-server' \  #Removed due to vulnerabilities and lack of updates upstream on this
-      'unified-language-server' \
-      'yaml-language-server@0.18.0' \
+    npm i -g bash-language-server  && \
+    dockerfile-language-server-nodejs &&  \
+    javascript-typescript-langserver && \
+    unified-language-server && \
+    yaml-language-server@0.18.0  && \
+    conda clean --all -f -y && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER  \
     && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -251,11 +251,12 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
       'r-languageserver' \
       'python-lsp-server' \
     && \
-    npm i -g bash-language-server  && \
-    dockerfile-language-server-nodejs &&  \
-    javascript-typescript-langserver && \
-    unified-language-server && \
-    yaml-language-server@0.18.0  && \
+    npm i -g \
+    'bash-language-server'  \
+    'dockerfile-language-server-nodejs' \
+    'javascript-typescript-langserver' \
+    'unified-language-server' \
+    'yaml-language-server@0.18.0'  && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER  \

--- a/output/sas/start-custom.sh
+++ b/output/sas/start-custom.sh
@@ -82,9 +82,9 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
-
+mkdir -p vscode-settings
 VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
-VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/vscode-settings/share/code-server/Machine/settings.json
 if [-f "$VS_CODE_PRESISTED" ]; then
     cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
 else
@@ -104,5 +104,5 @@ fi
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_SETTINGS_PERSIST=$HOME/vscode-settings/share/code-server/Machine/settings.json
 cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -82,9 +82,9 @@ export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
-
+mkdir -p vscode-settings
 VS_CODE_SETTINGS=/etc/share/code-server/Machine/settings.json
-VS_CODE_PRESISTED=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_PRESISTED=$HOME/vscode-settings/share/code-server/Machine/settings.json
 if [-f "$VS_CODE_PRESISTED" ]; then
     cp "$VS_CODE_PRESISTED" "$VS_CODE_SETTINGS"
 else
@@ -104,5 +104,5 @@ fi
                  --ServerApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}
 
 # persist vscode server remote settings (Machine dir)
-VS_CODE_SETTINGS_PERSIST=$HOME/.local/share/code-server/Machine/settings.json
+VS_CODE_SETTINGS_PERSIST=$HOME/vscode-settings/share/code-server/Machine/settings.json
 cp $VS_CODE_SETTINGS $VS_CODE_SETTINGS_PERSIST


### PR DESCRIPTION
# Description

**What your PR adds/fixes/removes**
Modifying the persisted directory for vscode settings to see if it fixes clients crashloopbackoff issues
# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
