### PR TITLE
Conda envs pointing to location inside the home folder (permanent conda environments)

### DIFF
--- a/docker-bits/0_cpu.Dockerfile
+++ b/docker-bits/0_cpu.Dockerfile
@@ -13,8 +13,10 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-
+# Added common conda configuration file to the user's home
+COPY .condarc /home/$NB_USER/.condarc
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \
   fix-permissions /home/$NB_USER
+

--- a/output/jupyterlab-cpu/.condarc
+++ b/output/jupyterlab-cpu/.condarc
@@ -1,0 +1,2 @@
+envs_dirs:
+  - $HOME/.conda/envs

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -23,11 +23,13 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-
+# Added common conda configuration file to the user's home
+COPY .condarc /home/$NB_USER/.condarc
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \
   fix-permissions /home/$NB_USER
+
 
 ###############################
 ###  docker-bits/3_Kubeflow.Dockerfile

--- a/output/jupyterlab-pytorch/.condarc
+++ b/output/jupyterlab-pytorch/.condarc
@@ -1,0 +1,2 @@
+envs_dirs:
+  - $HOME/.conda/envs

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -23,11 +23,13 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-
+# Added common conda configuration file to the user's home
+COPY .condarc /home/$NB_USER/.condarc
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \
   fix-permissions /home/$NB_USER
+
 
 ###############################
 ###  docker-bits/1_CUDA-11.7.Dockerfile

--- a/output/jupyterlab-tensorflow/.condarc
+++ b/output/jupyterlab-tensorflow/.condarc
@@ -1,0 +1,2 @@
+envs_dirs:
+  - $HOME/.conda/envs

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -23,11 +23,13 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-
+# Added common conda configuration file to the user's home
+COPY .condarc /home/$NB_USER/.condarc
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \
   fix-permissions /home/$NB_USER
+
 
 ###############################
 ###  docker-bits/1_CUDA-11.6.Dockerfile

--- a/output/rstudio/.condarc
+++ b/output/rstudio/.condarc
@@ -1,0 +1,2 @@
+envs_dirs:
+  - $HOME/.conda/envs

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -23,11 +23,13 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-
+# Added common conda configuration file to the user's home
+COPY .condarc /home/$NB_USER/.condarc
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \
   fix-permissions /home/$NB_USER
+
 
 ###############################
 ###  docker-bits/3_Kubeflow.Dockerfile

--- a/output/sas/.condarc
+++ b/output/sas/.condarc
@@ -1,0 +1,2 @@
+envs_dirs:
+  - $HOME/.conda/envs

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -18,11 +18,13 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-
+# Added common conda configuration file to the user's home
+COPY .condarc /home/$NB_USER/.condarc
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \
   fix-permissions /home/$NB_USER
+
 
 ###############################
 ###  docker-bits/3_Kubeflow.Dockerfile

--- a/resources/common/.condarc
+++ b/resources/common/.condarc
@@ -1,0 +1,2 @@
+envs_dirs:
+  - $HOME/.conda/envs


### PR DESCRIPTION
This resource specifies the location for conda envs to be created in $HOME/.conda/envs. Note: This does not affect the /opt/conda default envs location and the initial base env. Future environments are then stored in the specified condarc file. Reasoning:
Conda environments stored in the default /opt/conda are ephimeral. By selecting a location under $HOME we make sure that the pod configurations and environments are stored in a permanent volume.

# Description

**What your PR adds/fixes/removes**


# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
