### PR TITLE
fix(revert): forced venv, .condarc

### DIFF
--- a/docker-bits/0_cpu.Dockerfile
+++ b/docker-bits/0_cpu.Dockerfile
@@ -13,8 +13,7 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-# Added common conda configuration file to the user's home
-COPY .condarc /home/$NB_USER/.condarc
+
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \

--- a/output/docker-stacks-datascience-notebook/pip.conf
+++ b/output/docker-stacks-datascience-notebook/pip.conf
@@ -1,4 +1,3 @@
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
 index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
-require-virtualenv = true

--- a/output/docker-stacks-datascience-notebook/shell_helpers.sh
+++ b/output/docker-stacks-datascience-notebook/shell_helpers.sh
@@ -39,5 +39,5 @@ if [[ $(findmnt -n -o FSTYPE -T /home/jovyan) = 'fuse' ]]; then
   export _JAVA_OPTIONS=-Djna.tmpdir=/tmp
 fi
 
-# Activate the base python venv by default
-source $HOME/base-python-venv/bin/activate
+# Activate the base python venv by default revert for now, is causing issues
+# source $HOME/base-python-venv/bin/activate

--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -117,7 +117,7 @@ if [[ -f "$HOME/.condarc" ]]; then
   echo ".condarc file exists, not going to do anything"
 else
   echo "Creating basic .condarc file"
-  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
 
 

--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -100,16 +100,26 @@ echo "broken configuration settings removed"
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-export PIP_REQUIRE_VIRTUALENV=true
 
-echo "Checking if Python venv exists"
-if [[ -d "base-python-venv" ]]; then
-  echo "Base python venv exists, not going to create again"
+# Revert forced virtualenv, was causing issues with users
+#export PIP_REQUIRE_VIRTUALENV=true
+#echo "Checking if Python venv exists"
+#if [[ -d "base-python-venv" ]]; then
+#  echo "Base python venv exists, not going to create again"
+#else
+#  echo "Creating python venv"
+#  python3 -m venv $HOME/base-python-venv
+#  echo "adding include-system-site-packages"
+#fi
+
+echo "Checking for .condarc file in hom directory"
+if [[ -f "$HOME/.condarc" ]]; then
+  echo ".condarc file exists, not going to do anything"
 else
-  echo "Creating python venv"
-  python3 -m venv $HOME/base-python-venv
-  echo "adding include-system-site-packages"
+  echo "Creating basic .condarc file"
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
 fi
+
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 

--- a/output/jupyterlab-cpu/.condarc
+++ b/output/jupyterlab-cpu/.condarc
@@ -1,2 +1,0 @@
-envs_dirs:
-  - $HOME/.conda/envs

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -23,8 +23,7 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-# Added common conda configuration file to the user's home
-COPY .condarc /home/$NB_USER/.condarc
+
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \

--- a/output/jupyterlab-cpu/pip.conf
+++ b/output/jupyterlab-cpu/pip.conf
@@ -1,4 +1,3 @@
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
 index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
-require-virtualenv = true

--- a/output/jupyterlab-cpu/shell_helpers.sh
+++ b/output/jupyterlab-cpu/shell_helpers.sh
@@ -39,5 +39,5 @@ if [[ $(findmnt -n -o FSTYPE -T /home/jovyan) = 'fuse' ]]; then
   export _JAVA_OPTIONS=-Djna.tmpdir=/tmp
 fi
 
-# Activate the base python venv by default
-source $HOME/base-python-venv/bin/activate
+# Activate the base python venv by default revert for now, is causing issues
+# source $HOME/base-python-venv/bin/activate

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -117,7 +117,7 @@ if [[ -f "$HOME/.condarc" ]]; then
   echo ".condarc file exists, not going to do anything"
 else
   echo "Creating basic .condarc file"
-  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
 
 

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -100,16 +100,26 @@ echo "broken configuration settings removed"
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-export PIP_REQUIRE_VIRTUALENV=true
 
-echo "Checking if Python venv exists"
-if [[ -d "base-python-venv" ]]; then
-  echo "Base python venv exists, not going to create again"
+# Revert forced virtualenv, was causing issues with users
+#export PIP_REQUIRE_VIRTUALENV=true
+#echo "Checking if Python venv exists"
+#if [[ -d "base-python-venv" ]]; then
+#  echo "Base python venv exists, not going to create again"
+#else
+#  echo "Creating python venv"
+#  python3 -m venv $HOME/base-python-venv
+#  echo "adding include-system-site-packages"
+#fi
+
+echo "Checking for .condarc file in hom directory"
+if [[ -f "$HOME/.condarc" ]]; then
+  echo ".condarc file exists, not going to do anything"
 else
-  echo "Creating python venv"
-  python3 -m venv $HOME/base-python-venv
-  echo "adding include-system-site-packages"
+  echo "Creating basic .condarc file"
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
 fi
+
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 

--- a/output/jupyterlab-pytorch/.condarc
+++ b/output/jupyterlab-pytorch/.condarc
@@ -1,2 +1,0 @@
-envs_dirs:
-  - $HOME/.conda/envs

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -23,8 +23,7 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-# Added common conda configuration file to the user's home
-COPY .condarc /home/$NB_USER/.condarc
+
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \

--- a/output/jupyterlab-pytorch/pip.conf
+++ b/output/jupyterlab-pytorch/pip.conf
@@ -1,4 +1,3 @@
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
 index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
-require-virtualenv = true

--- a/output/jupyterlab-pytorch/shell_helpers.sh
+++ b/output/jupyterlab-pytorch/shell_helpers.sh
@@ -39,5 +39,5 @@ if [[ $(findmnt -n -o FSTYPE -T /home/jovyan) = 'fuse' ]]; then
   export _JAVA_OPTIONS=-Djna.tmpdir=/tmp
 fi
 
-# Activate the base python venv by default
-source $HOME/base-python-venv/bin/activate
+# Activate the base python venv by default revert for now, is causing issues
+# source $HOME/base-python-venv/bin/activate

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -117,7 +117,7 @@ if [[ -f "$HOME/.condarc" ]]; then
   echo ".condarc file exists, not going to do anything"
 else
   echo "Creating basic .condarc file"
-  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
 
 

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -100,16 +100,26 @@ echo "broken configuration settings removed"
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-export PIP_REQUIRE_VIRTUALENV=true
 
-echo "Checking if Python venv exists"
-if [[ -d "base-python-venv" ]]; then
-  echo "Base python venv exists, not going to create again"
+# Revert forced virtualenv, was causing issues with users
+#export PIP_REQUIRE_VIRTUALENV=true
+#echo "Checking if Python venv exists"
+#if [[ -d "base-python-venv" ]]; then
+#  echo "Base python venv exists, not going to create again"
+#else
+#  echo "Creating python venv"
+#  python3 -m venv $HOME/base-python-venv
+#  echo "adding include-system-site-packages"
+#fi
+
+echo "Checking for .condarc file in hom directory"
+if [[ -f "$HOME/.condarc" ]]; then
+  echo ".condarc file exists, not going to do anything"
 else
-  echo "Creating python venv"
-  python3 -m venv $HOME/base-python-venv
-  echo "adding include-system-site-packages"
+  echo "Creating basic .condarc file"
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
 fi
+
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 

--- a/output/jupyterlab-tensorflow/.condarc
+++ b/output/jupyterlab-tensorflow/.condarc
@@ -1,2 +1,0 @@
-envs_dirs:
-  - $HOME/.conda/envs

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -23,8 +23,7 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-# Added common conda configuration file to the user's home
-COPY .condarc /home/$NB_USER/.condarc
+
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \

--- a/output/jupyterlab-tensorflow/pip.conf
+++ b/output/jupyterlab-tensorflow/pip.conf
@@ -1,4 +1,3 @@
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
 index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
-require-virtualenv = true

--- a/output/jupyterlab-tensorflow/shell_helpers.sh
+++ b/output/jupyterlab-tensorflow/shell_helpers.sh
@@ -39,5 +39,5 @@ if [[ $(findmnt -n -o FSTYPE -T /home/jovyan) = 'fuse' ]]; then
   export _JAVA_OPTIONS=-Djna.tmpdir=/tmp
 fi
 
-# Activate the base python venv by default
-source $HOME/base-python-venv/bin/activate
+# Activate the base python venv by default revert for now, is causing issues
+# source $HOME/base-python-venv/bin/activate

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -117,7 +117,7 @@ if [[ -f "$HOME/.condarc" ]]; then
   echo ".condarc file exists, not going to do anything"
 else
   echo "Creating basic .condarc file"
-  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
 
 

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -100,16 +100,26 @@ echo "broken configuration settings removed"
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-export PIP_REQUIRE_VIRTUALENV=true
 
-echo "Checking if Python venv exists"
-if [[ -d "base-python-venv" ]]; then
-  echo "Base python venv exists, not going to create again"
+# Revert forced virtualenv, was causing issues with users
+#export PIP_REQUIRE_VIRTUALENV=true
+#echo "Checking if Python venv exists"
+#if [[ -d "base-python-venv" ]]; then
+#  echo "Base python venv exists, not going to create again"
+#else
+#  echo "Creating python venv"
+#  python3 -m venv $HOME/base-python-venv
+#  echo "adding include-system-site-packages"
+#fi
+
+echo "Checking for .condarc file in hom directory"
+if [[ -f "$HOME/.condarc" ]]; then
+  echo ".condarc file exists, not going to do anything"
 else
-  echo "Creating python venv"
-  python3 -m venv $HOME/base-python-venv
-  echo "adding include-system-site-packages"
+  echo "Creating basic .condarc file"
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
 fi
+
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 

--- a/output/remote-desktop/pip.conf
+++ b/output/remote-desktop/pip.conf
@@ -1,4 +1,3 @@
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
 index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
-require-virtualenv = true

--- a/output/remote-desktop/shell_helpers.sh
+++ b/output/remote-desktop/shell_helpers.sh
@@ -39,5 +39,5 @@ if [[ $(findmnt -n -o FSTYPE -T /home/jovyan) = 'fuse' ]]; then
   export _JAVA_OPTIONS=-Djna.tmpdir=/tmp
 fi
 
-# Activate the base python venv by default
-source $HOME/base-python-venv/bin/activate
+# Activate the base python venv by default revert for now, is causing issues
+# source $HOME/base-python-venv/bin/activate

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -117,7 +117,7 @@ if [[ -f "$HOME/.condarc" ]]; then
   echo ".condarc file exists, not going to do anything"
 else
   echo "Creating basic .condarc file"
-  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
 
 

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -100,16 +100,26 @@ echo "broken configuration settings removed"
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-export PIP_REQUIRE_VIRTUALENV=true
 
-echo "Checking if Python venv exists"
-if [[ -d "base-python-venv" ]]; then
-  echo "Base python venv exists, not going to create again"
+# Revert forced virtualenv, was causing issues with users
+#export PIP_REQUIRE_VIRTUALENV=true
+#echo "Checking if Python venv exists"
+#if [[ -d "base-python-venv" ]]; then
+#  echo "Base python venv exists, not going to create again"
+#else
+#  echo "Creating python venv"
+#  python3 -m venv $HOME/base-python-venv
+#  echo "adding include-system-site-packages"
+#fi
+
+echo "Checking for .condarc file in hom directory"
+if [[ -f "$HOME/.condarc" ]]; then
+  echo ".condarc file exists, not going to do anything"
 else
-  echo "Creating python venv"
-  python3 -m venv $HOME/base-python-venv
-  echo "adding include-system-site-packages"
+  echo "Creating basic .condarc file"
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
 fi
+
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 

--- a/output/remote-desktop/start-remote-desktop.sh
+++ b/output/remote-desktop/start-remote-desktop.sh
@@ -83,15 +83,24 @@ fi
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(echo /var/run/secrets/kubernetes.io/serviceaccount/token)"
-export PIP_REQUIRE_VIRTUALENV=true
 
-echo "Checking if Python venv exists"
-if [[ -d "base-python-venv" ]]; then
-  echo "Base python venv exists, not going to create again"
+# Revert, is causing issues
+#export PIP_REQUIRE_VIRTUALENV=true
+#echo "Checking if Python venv exists"
+#if [[ -d "base-python-venv" ]]; then
+#  echo "Base python venv exists, not going to create again"
+#else
+#  echo "Creating python venv"
+#  python3 -m venv $HOME/base-python-venv
+#  echo "adding include-system-site-packages"
+#fi
+
+echo "Checking for .condarc file in hom directory"
+if [[ -f "$HOME/.condarc" ]]; then
+  echo ".condarc file exists, not going to do anything"
 else
-  echo "Creating python venv"
-  python3 -m venv $HOME/base-python-venv
-  echo "adding include-system-site-packages"
+  echo "Creating basic .condarc file"
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
 fi
 
 mkdir -p $HOME/.vnc

--- a/output/remote-desktop/start-remote-desktop.sh
+++ b/output/remote-desktop/start-remote-desktop.sh
@@ -100,7 +100,7 @@ if [[ -f "$HOME/.condarc" ]]; then
   echo ".condarc file exists, not going to do anything"
 else
   echo "Creating basic .condarc file"
-  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
 
 mkdir -p $HOME/.vnc

--- a/output/rstudio/.condarc
+++ b/output/rstudio/.condarc
@@ -1,2 +1,0 @@
-envs_dirs:
-  - $HOME/.conda/envs

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -23,8 +23,7 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-# Added common conda configuration file to the user's home
-COPY .condarc /home/$NB_USER/.condarc
+
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \

--- a/output/rstudio/pip.conf
+++ b/output/rstudio/pip.conf
@@ -1,4 +1,3 @@
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
 index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
-require-virtualenv = true

--- a/output/rstudio/shell_helpers.sh
+++ b/output/rstudio/shell_helpers.sh
@@ -39,5 +39,5 @@ if [[ $(findmnt -n -o FSTYPE -T /home/jovyan) = 'fuse' ]]; then
   export _JAVA_OPTIONS=-Djna.tmpdir=/tmp
 fi
 
-# Activate the base python venv by default
-source $HOME/base-python-venv/bin/activate
+# Activate the base python venv by default revert for now, is causing issues
+# source $HOME/base-python-venv/bin/activate

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -117,7 +117,7 @@ if [[ -f "$HOME/.condarc" ]]; then
   echo ".condarc file exists, not going to do anything"
 else
   echo "Creating basic .condarc file"
-  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
 
 

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -100,16 +100,26 @@ echo "broken configuration settings removed"
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-export PIP_REQUIRE_VIRTUALENV=true
 
-echo "Checking if Python venv exists"
-if [[ -d "base-python-venv" ]]; then
-  echo "Base python venv exists, not going to create again"
+# Revert forced virtualenv, was causing issues with users
+#export PIP_REQUIRE_VIRTUALENV=true
+#echo "Checking if Python venv exists"
+#if [[ -d "base-python-venv" ]]; then
+#  echo "Base python venv exists, not going to create again"
+#else
+#  echo "Creating python venv"
+#  python3 -m venv $HOME/base-python-venv
+#  echo "adding include-system-site-packages"
+#fi
+
+echo "Checking for .condarc file in hom directory"
+if [[ -f "$HOME/.condarc" ]]; then
+  echo ".condarc file exists, not going to do anything"
 else
-  echo "Creating python venv"
-  python3 -m venv $HOME/base-python-venv
-  echo "adding include-system-site-packages"
+  echo "Creating basic .condarc file"
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
 fi
+
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 

--- a/output/sas/.condarc
+++ b/output/sas/.condarc
@@ -1,2 +1,0 @@
-envs_dirs:
-  - $HOME/.conda/envs

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -18,8 +18,7 @@ ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 RUN apt-get update --yes \
     && apt-get install --yes language-pack-fr \
     && rm -rf /var/lib/apt/lists/*
-# Added common conda configuration file to the user's home
-COPY .condarc /home/$NB_USER/.condarc
+
 # Python is downgraded because of ml-metadata
 RUN conda install -c conda-forge python=3.8.12 -y && \
   fix-permissions $CONDA_DIR && \

--- a/output/sas/pip.conf
+++ b/output/sas/pip.conf
@@ -1,4 +1,3 @@
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
 index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
-require-virtualenv = true

--- a/output/sas/shell_helpers.sh
+++ b/output/sas/shell_helpers.sh
@@ -39,5 +39,5 @@ if [[ $(findmnt -n -o FSTYPE -T /home/jovyan) = 'fuse' ]]; then
   export _JAVA_OPTIONS=-Djna.tmpdir=/tmp
 fi
 
-# Activate the base python venv by default
-source $HOME/base-python-venv/bin/activate
+# Activate the base python venv by default revert for now, is causing issues
+# source $HOME/base-python-venv/bin/activate

--- a/output/sas/start-custom.sh
+++ b/output/sas/start-custom.sh
@@ -117,7 +117,7 @@ if [[ -f "$HOME/.condarc" ]]; then
   echo ".condarc file exists, not going to do anything"
 else
   echo "Creating basic .condarc file"
-  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
 
 

--- a/output/sas/start-custom.sh
+++ b/output/sas/start-custom.sh
@@ -100,16 +100,26 @@ echo "broken configuration settings removed"
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-export PIP_REQUIRE_VIRTUALENV=true
 
-echo "Checking if Python venv exists"
-if [[ -d "base-python-venv" ]]; then
-  echo "Base python venv exists, not going to create again"
+# Revert forced virtualenv, was causing issues with users
+#export PIP_REQUIRE_VIRTUALENV=true
+#echo "Checking if Python venv exists"
+#if [[ -d "base-python-venv" ]]; then
+#  echo "Base python venv exists, not going to create again"
+#else
+#  echo "Creating python venv"
+#  python3 -m venv $HOME/base-python-venv
+#  echo "adding include-system-site-packages"
+#fi
+
+echo "Checking for .condarc file in hom directory"
+if [[ -f "$HOME/.condarc" ]]; then
+  echo ".condarc file exists, not going to do anything"
 else
-  echo "Creating python venv"
-  python3 -m venv $HOME/base-python-venv
-  echo "adding include-system-site-packages"
+  echo "Creating basic .condarc file"
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
 fi
+
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 

--- a/resources/common/.condarc
+++ b/resources/common/.condarc
@@ -1,2 +1,0 @@
-envs_dirs:
-  - $HOME/.conda/envs

--- a/resources/common/pip.conf
+++ b/resources/common/pip.conf
@@ -1,4 +1,3 @@
 [global]
 trusted-host = jfrog-platform-artifactory-ha.jfrog-system
 index-url = http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/pypi/pypi-remote/simple
-require-virtualenv = true

--- a/resources/common/shell_helpers.sh
+++ b/resources/common/shell_helpers.sh
@@ -39,5 +39,5 @@ if [[ $(findmnt -n -o FSTYPE -T /home/jovyan) = 'fuse' ]]; then
   export _JAVA_OPTIONS=-Djna.tmpdir=/tmp
 fi
 
-# Activate the base python venv by default
-source $HOME/base-python-venv/bin/activate
+# Activate the base python venv by default revert for now, is causing issues
+# source $HOME/base-python-venv/bin/activate

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -117,7 +117,7 @@ if [[ -f "$HOME/.condarc" ]]; then
   echo ".condarc file exists, not going to do anything"
 else
   echo "Creating basic .condarc file"
-  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
 
 

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -100,16 +100,26 @@ echo "broken configuration settings removed"
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-export PIP_REQUIRE_VIRTUALENV=true
 
-echo "Checking if Python venv exists"
-if [[ -d "base-python-venv" ]]; then
-  echo "Base python venv exists, not going to create again"
+# Revert forced virtualenv, was causing issues with users
+#export PIP_REQUIRE_VIRTUALENV=true
+#echo "Checking if Python venv exists"
+#if [[ -d "base-python-venv" ]]; then
+#  echo "Base python venv exists, not going to create again"
+#else
+#  echo "Creating python venv"
+#  python3 -m venv $HOME/base-python-venv
+#  echo "adding include-system-site-packages"
+#fi
+
+echo "Checking for .condarc file in hom directory"
+if [[ -f "$HOME/.condarc" ]]; then
+  echo ".condarc file exists, not going to do anything"
 else
-  echo "Creating python venv"
-  python3 -m venv $HOME/base-python-venv
-  echo "adding include-system-site-packages"
+  echo "Creating basic .condarc file"
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
 fi
+
 
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 

--- a/resources/remote-desktop/start-remote-desktop.sh
+++ b/resources/remote-desktop/start-remote-desktop.sh
@@ -83,15 +83,24 @@ fi
 
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(echo /var/run/secrets/kubernetes.io/serviceaccount/token)"
-export PIP_REQUIRE_VIRTUALENV=true
 
-echo "Checking if Python venv exists"
-if [[ -d "base-python-venv" ]]; then
-  echo "Base python venv exists, not going to create again"
+# Revert, is causing issues
+#export PIP_REQUIRE_VIRTUALENV=true
+#echo "Checking if Python venv exists"
+#if [[ -d "base-python-venv" ]]; then
+#  echo "Base python venv exists, not going to create again"
+#else
+#  echo "Creating python venv"
+#  python3 -m venv $HOME/base-python-venv
+#  echo "adding include-system-site-packages"
+#fi
+
+echo "Checking for .condarc file in hom directory"
+if [[ -f "$HOME/.condarc" ]]; then
+  echo ".condarc file exists, not going to do anything"
 else
-  echo "Creating python venv"
-  python3 -m venv $HOME/base-python-venv
-  echo "adding include-system-site-packages"
+  echo "Creating basic .condarc file"
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
 fi
 
 mkdir -p $HOME/.vnc

--- a/resources/remote-desktop/start-remote-desktop.sh
+++ b/resources/remote-desktop/start-remote-desktop.sh
@@ -100,7 +100,7 @@ if [[ -f "$HOME/.condarc" ]]; then
   echo ".condarc file exists, not going to do anything"
 else
   echo "Creating basic .condarc file"
-  printf 'envs_dirs:\n  - $HOME/.conda/envs' > .condarc
+  printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
 
 mkdir -p $HOME/.vnc


### PR DESCRIPTION
Closes https://github.com/StatCan/aaw-kubeflow-containers/issues/426

Will make more details shortly.

@asolis you can review it / give it a quick glance-over if you want, all i really did was comment out any forced virtual environment creation and requirements and then create the .condarc in the startup script if it does not exist already