### PR TITLE
updated pytorch versions to fix cve

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -66,12 +66,12 @@ jobs:
         notebook:
           # TODO: Pull this from a settings file or Makefile, that way Make can have the same list
           # - docker-stacks-datascience-notebook # Debugging
-          #- rstudio
-          #- sas
-          #- jupyterlab-cpu
+          - rstudio
+          - sas
+          - jupyterlab-cpu
           - jupyterlab-pytorch
-          #- jupyterlab-tensorflow
-          #- remote-desktop
+          - jupyterlab-tensorflow
+          - remote-desktop
     needs: pre-build-checks
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -66,12 +66,12 @@ jobs:
         notebook:
           # TODO: Pull this from a settings file or Makefile, that way Make can have the same list
           # - docker-stacks-datascience-notebook # Debugging
-          - rstudio
-          - sas
-          - jupyterlab-cpu
+          #- rstudio
+          #- sas
+          #- jupyterlab-cpu
           - jupyterlab-pytorch
-          - jupyterlab-tensorflow
-          - remote-desktop
+          #- jupyterlab-tensorflow
+          #- remote-desktop
     needs: pre-build-checks
     runs-on: ubuntu-latest
     services:

--- a/docker-bits/2_pytorch.Dockerfile
+++ b/docker-bits/2_pytorch.Dockerfile
@@ -1,12 +1,12 @@
 #Install PyTorch
-RUN conda create -n torch python=3.7 && \
+RUN conda create -n torch python=3.9 && \
    conda install -n torch --quiet --yes -c pytorch \
-     'pytorch==1.6.0' \
-     'torchvision==0.7.0' \
+     'pytorch==1.13.1' \
+     'torchvision==0.14.1' \
      'ipykernel==5.3.4' \
    && \
    conda install -n torch --quiet --yes -c pytorch \
-     'torchtext==0.7.0' \
+     'torchtext==0.14.1' \
    && \
    conda clean --all -f -y && \
    fix-permissions $CONDA_DIR && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -101,14 +101,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ###############################
 
 #Install PyTorch
-RUN conda create -n torch python=3.7 && \
+RUN conda create -n torch python=3.9 && \
    conda install -n torch --quiet --yes -c pytorch \
-     'pytorch==1.6.0' \
-     'torchvision==0.7.0' \
+     'pytorch==1.13.1' \
+     'torchvision==0.14.1' \
      'ipykernel==5.3.4' \
    && \
    conda install -n torch --quiet --yes -c pytorch \
-     'torchtext==0.7.0' \
+     'torchtext==0.14.1' \
    && \
    conda clean --all -f -y && \
    fix-permissions $CONDA_DIR && \


### PR DESCRIPTION
# Description
 Closes https://github.com/StatCan/daaas-private/issues/43

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [x] Do we want to maintain the previous image from which we had to do breaking changes from? No

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [x] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [x] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [x] Does VS Code open?
- [x] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
