### PR TITLE
chore(conda):add more channels

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -66,11 +66,12 @@ jobs:
         notebook:
           # TODO: Pull this from a settings file or Makefile, that way Make can have the same list
           # - docker-stacks-datascience-notebook # Debugging
-          - rstudio
-          - sas
+          # Test things
+          #- rstudio
+          #- sas
           - jupyterlab-cpu
-          - jupyterlab-pytorch
-          - jupyterlab-tensorflow
+          #- jupyterlab-pytorch
+          #- jupyterlab-tensorflow
           - remote-desktop
     needs: pre-build-checks
     runs-on: ubuntu-latest
@@ -82,8 +83,9 @@ jobs:
     steps:
     - name: Set ENV variables for a PR containing the auto-deploy tag
       if: github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'auto-deploy')
+      ## REVERT LATER
       run: | 
-        echo "REGISTRY=k8scc01covidacrdev.azurecr.io" >> "$GITHUB_ENV"
+        echo "REGISTRY=k8scc01covidacr.azurecr.io" >> "$GITHUB_ENV"
         echo "IMAGE_VERSION=dev" >> "$GITHUB_ENV"
    
     - name: Set ENV variables for pushes to master

--- a/docker-bits/∞_CMD.Dockerfile
+++ b/docker-bits/∞_CMD.Dockerfile
@@ -17,7 +17,9 @@ RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rpro
 
 # Point conda to Artifactory repository
 RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
-    conda config --remove channels conda-forge --system
+    conda config --remove channels conda-forge --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]

--- a/output/docker-stacks-datascience-notebook/Dockerfile
+++ b/output/docker-stacks-datascience-notebook/Dockerfile
@@ -23,7 +23,9 @@ RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rpro
 
 # Point conda to Artifactory repository
 RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
-    conda config --remove channels conda-forge --system
+    conda config --remove channels conda-forge --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -301,7 +301,9 @@ RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rpro
 
 # Point conda to Artifactory repository
 RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
-    conda config --remove channels conda-forge --system
+    conda config --remove channels conda-forge --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -385,7 +385,9 @@ RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rpro
 
 # Point conda to Artifactory repository
 RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
-    conda config --remove channels conda-forge --system
+    conda config --remove channels conda-forge --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -380,7 +380,9 @@ RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rpro
 
 # Point conda to Artifactory repository
 RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
-    conda config --remove channels conda-forge --system
+    conda config --remove channels conda-forge --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]

--- a/output/remote-desktop/.condarc
+++ b/output/remote-desktop/.condarc
@@ -1,4 +1,7 @@
 channels:
   - http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote
+  - http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia
+  - http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote
+
 auto_update_conda: false
 show_channel_urls: true

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -228,7 +228,9 @@ RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rpro
 
 # Point conda to Artifactory repository
 RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
-    conda config --remove channels conda-forge --system
+    conda config --remove channels conda-forge --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -413,7 +413,9 @@ RUN cat /tmp/Rprofile.site >> /opt/conda/lib/R/etc/Rprofile.site && rm /tmp/Rpro
 
 # Point conda to Artifactory repository
 RUN conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote --system && \
-    conda config --remove channels conda-forge --system
+    conda config --remove channels conda-forge --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
+    conda config --add channels http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]

--- a/resources/remote-desktop/.condarc
+++ b/resources/remote-desktop/.condarc
@@ -1,4 +1,7 @@
 channels:
   - http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-remote
+  - http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia
+  - http://jfrog-platform-artifactory-ha.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote
+
 auto_update_conda: false
 show_channel_urls: true


### PR DESCRIPTION
# Description

Closes https://github.com/StatCan/daaas/issues/1405

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?


Have to test both jlab and remote desktop in prod

