### PR TITLE
fix(code-server): replace R extension

### DIFF
--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -38,7 +38,7 @@ COPY languagepacks.json $XDG_DATA_HOME/code-server/
 ARG SHA256py=10368d0175e34583a84935e691dba122d4ece2e23305700f226b6807508a30b1
 
 RUN code-server --install-extension ms-python.python@2022.16.1 && \
-    code-server --install-extension ikuyadeu.r@2.4.0 && \
+    code-server --install-extension REditorSupport.r@2.7.0 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
     code-server --install-extension quarto.quarto@1.53.1 && \
     fix-permissions $XDG_DATA_HOME

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -46,7 +46,7 @@ COPY languagepacks.json $XDG_DATA_HOME/code-server/
 ARG SHA256py=10368d0175e34583a84935e691dba122d4ece2e23305700f226b6807508a30b1
 
 RUN code-server --install-extension ms-python.python@2022.16.1 && \
-    code-server --install-extension ikuyadeu.r@2.4.0 && \
+    code-server --install-extension REditorSupport.r@2.7.0 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
     code-server --install-extension quarto.quarto@1.53.1 && \
     fix-permissions $XDG_DATA_HOME

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -181,7 +181,7 @@ COPY languagepacks.json $XDG_DATA_HOME/code-server/
 ARG SHA256py=10368d0175e34583a84935e691dba122d4ece2e23305700f226b6807508a30b1
 
 RUN code-server --install-extension ms-python.python@2022.16.1 && \
-    code-server --install-extension ikuyadeu.r@2.4.0 && \
+    code-server --install-extension REditorSupport.r@2.7.0 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
     code-server --install-extension quarto.quarto@1.53.1 && \
     fix-permissions $XDG_DATA_HOME

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -265,7 +265,7 @@ COPY languagepacks.json $XDG_DATA_HOME/code-server/
 ARG SHA256py=10368d0175e34583a84935e691dba122d4ece2e23305700f226b6807508a30b1
 
 RUN code-server --install-extension ms-python.python@2022.16.1 && \
-    code-server --install-extension ikuyadeu.r@2.4.0 && \
+    code-server --install-extension REditorSupport.r@2.7.0 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
     code-server --install-extension quarto.quarto@1.53.1 && \
     fix-permissions $XDG_DATA_HOME

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -260,7 +260,7 @@ COPY languagepacks.json $XDG_DATA_HOME/code-server/
 ARG SHA256py=10368d0175e34583a84935e691dba122d4ece2e23305700f226b6807508a30b1
 
 RUN code-server --install-extension ms-python.python@2022.16.1 && \
-    code-server --install-extension ikuyadeu.r@2.4.0 && \
+    code-server --install-extension REditorSupport.r@2.7.0 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
     code-server --install-extension quarto.quarto@1.53.1 && \
     fix-permissions $XDG_DATA_HOME

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -312,7 +312,7 @@ COPY languagepacks.json $XDG_DATA_HOME/code-server/
 ARG SHA256py=10368d0175e34583a84935e691dba122d4ece2e23305700f226b6807508a30b1
 
 RUN code-server --install-extension ms-python.python@2022.16.1 && \
-    code-server --install-extension ikuyadeu.r@2.4.0 && \
+    code-server --install-extension REditorSupport.r@2.7.0 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
     code-server --install-extension quarto.quarto@1.53.1 && \
     fix-permissions $XDG_DATA_HOME

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -176,7 +176,7 @@ COPY languagepacks.json $XDG_DATA_HOME/code-server/
 ARG SHA256py=10368d0175e34583a84935e691dba122d4ece2e23305700f226b6807508a30b1
 
 RUN code-server --install-extension ms-python.python@2022.16.1 && \
-    code-server --install-extension ikuyadeu.r@2.4.0 && \
+    code-server --install-extension REditorSupport.r@2.7.0 && \
     code-server --install-extension MS-CEINTL.vscode-language-pack-fr@1.68.3 && \
     code-server --install-extension quarto.quarto@1.53.1 && \
     fix-permissions $XDG_DATA_HOME


### PR DESCRIPTION
# Description

Replaces the R extension since with the official one at https://open-vsx.org/extension/REditorSupport/r

# Tests / Quality Checks


## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
