### PR TITLE
updated base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # https://github.com/jupyter/docker-stacks/blob/master/Makefile
 
 # The docker-stacks tag
-DOCKER-STACKS-UPSTREAM-TAG := ed2908bbb62e
+DOCKER-STACKS-UPSTREAM-TAG := cde8b4389ade
 
 tensorflow-CUDA := 11.7
 pytorch-CUDA    := 11.7

--- a/docker-bits/0_cpu.Dockerfile
+++ b/docker-bits/0_cpu.Dockerfile
@@ -3,7 +3,7 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=ed2908bbb62e
+ARG BASE_VERSION=cde8b4389ade
 FROM jupyter/datascience-notebook:$BASE_VERSION
 
 USER root

--- a/output/docker-stacks-datascience-notebook/Dockerfile
+++ b/output/docker-stacks-datascience-notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:ed2908bbb62e
+FROM jupyter/datascience-notebook:cde8b4389ade
 
 ###############################
 ###  docker-bits/∞_CMD.Dockerfile

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -13,7 +13,7 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=ed2908bbb62e
+ARG BASE_VERSION=cde8b4389ade
 FROM jupyter/datascience-notebook:$BASE_VERSION
 
 USER root

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -13,7 +13,7 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=ed2908bbb62e
+ARG BASE_VERSION=cde8b4389ade
 FROM jupyter/datascience-notebook:$BASE_VERSION
 
 USER root

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -13,7 +13,7 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=ed2908bbb62e
+ARG BASE_VERSION=cde8b4389ade
 FROM jupyter/datascience-notebook:$BASE_VERSION
 
 USER root

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -13,7 +13,7 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=ed2908bbb62e
+ARG BASE_VERSION=cde8b4389ade
 FROM jupyter/datascience-notebook:$BASE_VERSION
 
 USER root


### PR DESCRIPTION
# Description

closes https://github.com/StatCan/daaas-private/issues/57

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
