### PR TITLE
feat(Editor): change default to nano

### DIFF
--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -31,6 +31,9 @@ if [ ! -f /home/$NB_USER/.zsh-installed ]; then
     touch /home/$NB_USER/.hushlogin
 fi
 
+export VISUAL="/usr/bin/nano"
+export EDITOR="$VISUAL"
+
 echo "shell has been configured"
 
 # create .profile

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -31,6 +31,9 @@ if [ ! -f /home/$NB_USER/.zsh-installed ]; then
     touch /home/$NB_USER/.hushlogin
 fi
 
+export VISUAL="/usr/bin/nano"
+export EDITOR="$VISUAL"
+
 echo "shell has been configured"
 
 # create .profile

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -31,6 +31,9 @@ if [ ! -f /home/$NB_USER/.zsh-installed ]; then
     touch /home/$NB_USER/.hushlogin
 fi
 
+export VISUAL="/usr/bin/nano"
+export EDITOR="$VISUAL"
+
 echo "shell has been configured"
 
 # create .profile

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -31,6 +31,9 @@ if [ ! -f /home/$NB_USER/.zsh-installed ]; then
     touch /home/$NB_USER/.hushlogin
 fi
 
+export VISUAL="/usr/bin/nano"
+export EDITOR="$VISUAL"
+
 echo "shell has been configured"
 
 # create .profile

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -31,6 +31,9 @@ if [ ! -f /home/$NB_USER/.zsh-installed ]; then
     touch /home/$NB_USER/.hushlogin
 fi
 
+export VISUAL="/usr/bin/nano"
+export EDITOR="$VISUAL"
+
 echo "shell has been configured"
 
 # create .profile

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -31,6 +31,9 @@ if [ ! -f /home/$NB_USER/.zsh-installed ]; then
     touch /home/$NB_USER/.hushlogin
 fi
 
+export VISUAL="/usr/bin/nano"
+export EDITOR="$VISUAL"
+
 echo "shell has been configured"
 
 # create .profile

--- a/output/sas/start-custom.sh
+++ b/output/sas/start-custom.sh
@@ -31,6 +31,9 @@ if [ ! -f /home/$NB_USER/.zsh-installed ]; then
     touch /home/$NB_USER/.hushlogin
 fi
 
+export VISUAL="/usr/bin/nano"
+export EDITOR="$VISUAL"
+
 echo "shell has been configured"
 
 # create .profile

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -31,6 +31,9 @@ if [ ! -f /home/$NB_USER/.zsh-installed ]; then
     touch /home/$NB_USER/.hushlogin
 fi
 
+export VISUAL="/usr/bin/nano"
+export EDITOR="$VISUAL"
+
 echo "shell has been configured"
 
 # create .profile


### PR DESCRIPTION
# Description

Changes the default editor to `nano`

Closes https://github.com/StatCan/aaw-kubeflow-containers/issues/331

Processes which open an editor default to nano, example `git commit`:

![image](https://user-images.githubusercontent.com/35379392/222261633-ac5fa613-02e9-4c2b-bbc9-663b07291b11.png)

**Test image** : `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:434be744038c04795557abec0999075ab6038947`

## Code review

- [x] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [x] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
