### PR TITLE
Add slack notifications for nightly build

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -58,7 +58,7 @@ jobs:
       uses: act10ns/slack@v1
       with: 
         status: failure
-        message: Build failed. https://github.com/StatCan/disclosure-vetting-application/actions/runs/${{github.run_id}}
+        message: Build failed. https://github.com/StatCan/aaw-kubeflow-containers/actions/runs/${{github.run_id}}
         
   build-push:
     env:
@@ -214,4 +214,4 @@ jobs:
       uses: act10ns/slack@v1
       with: 
         status: failure
-        message: Build failed. https://github.com/StatCan/disclosure-vetting-application/actions/runs/${{github.run_id}}
+        message: Build failed. https://github.com/StatCan/aaw-kubeflow-containers/actions/runs/${{github.run_id}}

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -53,12 +53,6 @@ jobs:
             echo 'output folder and docker-bits/resources out of sync!'
             exit 1
         fi
-    - name: Slack Notification
-      if: failure() && github.event_name=='schedule'
-      uses: act10ns/slack@v1
-      with: 
-        status: failure
-        message: Build failed. https://github.com/StatCan/aaw-kubeflow-containers/actions/runs/${{github.run_id}}
         
   build-push:
     env:

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -34,7 +34,9 @@ on:
       - 'opened'
       - 'synchronize'
       - 'reopened'
-
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  
 jobs:
   # Any checks that run pre-build
   pre-build-checks:
@@ -51,7 +53,13 @@ jobs:
             echo 'output folder and docker-bits/resources out of sync!'
             exit 1
         fi
-
+    - name: Slack Notification
+      if: failure() && github.event_name=='schedule'
+      uses: act10ns/slack@v1
+      with: 
+        status: failure
+        message: Build failed. https://github.com/StatCan/disclosure-vetting-application/actions/runs/${{github.run_id}}
+        
   build-push:
     env:
       REGISTRY_NAME: k8scc01covidacr
@@ -200,3 +208,10 @@ jobs:
       if: steps.should-i-push.outputs.boolean == 'true'
       run: |
         make push/${{ matrix.notebook }} DEFAULT_REPO=$REGISTRY
+        
+    - name: Slack Notification
+      if: failure() && github.event_name=='schedule'
+      uses: act10ns/slack@v1
+      with: 
+        status: failure
+        message: Build failed. https://github.com/StatCan/disclosure-vetting-application/actions/runs/${{github.run_id}}


### PR DESCRIPTION
Added slack notification for the 2 declared jobs. It will send a slack notification only if the schedule event (night build) fails (aka a failure occurs in declared jobs).

closes https://github.com/StatCan/aaw-kubeflow-containers/issues/326