### PR TITLE
chore(sus script): fix shebang add argument

### DIFF
--- a/output/docker-stacks-datascience-notebook/aaw-suspend-server.sh
+++ b/output/docker-stacks-datascience-notebook/aaw-suspend-server.sh
@@ -1,7 +1,19 @@
-#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
 #!/bin/bash
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/478
+
+time_wait=$1
+if ! [ ${time_wait:+1} ]
+then
+    time_wait=30
+fi
+
+echo "Waiting $time_wait seconds before shutting down server (press ctrl-c to stop shutdown)..."
+sleep $time_wait
+
 nb_server_name=`echo $NB_PREFIX | perl -pe 's/^.*\///'`
 tag_date=`date +%Y-%m-%d"T"%H:%M:%SZ`
+
 echo "Shutting down server named $nb_server_name in namespace $NB_NAMESPACE with date tag $tag_date."
 kubectl annotate notebook/$nb_server_name kubeflow-resource-stopped=$tag_date -n $NB_NAMESPACE
 echo "Command had return code $?."

--- a/output/jupyterlab-cpu/aaw-suspend-server.sh
+++ b/output/jupyterlab-cpu/aaw-suspend-server.sh
@@ -1,7 +1,19 @@
-#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
 #!/bin/bash
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/478
+
+time_wait=$1
+if ! [ ${time_wait:+1} ]
+then
+    time_wait=30
+fi
+
+echo "Waiting $time_wait seconds before shutting down server (press ctrl-c to stop shutdown)..."
+sleep $time_wait
+
 nb_server_name=`echo $NB_PREFIX | perl -pe 's/^.*\///'`
 tag_date=`date +%Y-%m-%d"T"%H:%M:%SZ`
+
 echo "Shutting down server named $nb_server_name in namespace $NB_NAMESPACE with date tag $tag_date."
 kubectl annotate notebook/$nb_server_name kubeflow-resource-stopped=$tag_date -n $NB_NAMESPACE
 echo "Command had return code $?."

--- a/output/jupyterlab-pytorch/aaw-suspend-server.sh
+++ b/output/jupyterlab-pytorch/aaw-suspend-server.sh
@@ -1,7 +1,19 @@
-#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
 #!/bin/bash
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/478
+
+time_wait=$1
+if ! [ ${time_wait:+1} ]
+then
+    time_wait=30
+fi
+
+echo "Waiting $time_wait seconds before shutting down server (press ctrl-c to stop shutdown)..."
+sleep $time_wait
+
 nb_server_name=`echo $NB_PREFIX | perl -pe 's/^.*\///'`
 tag_date=`date +%Y-%m-%d"T"%H:%M:%SZ`
+
 echo "Shutting down server named $nb_server_name in namespace $NB_NAMESPACE with date tag $tag_date."
 kubectl annotate notebook/$nb_server_name kubeflow-resource-stopped=$tag_date -n $NB_NAMESPACE
 echo "Command had return code $?."

--- a/output/jupyterlab-tensorflow/aaw-suspend-server.sh
+++ b/output/jupyterlab-tensorflow/aaw-suspend-server.sh
@@ -1,7 +1,19 @@
-#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
 #!/bin/bash
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/478
+
+time_wait=$1
+if ! [ ${time_wait:+1} ]
+then
+    time_wait=30
+fi
+
+echo "Waiting $time_wait seconds before shutting down server (press ctrl-c to stop shutdown)..."
+sleep $time_wait
+
 nb_server_name=`echo $NB_PREFIX | perl -pe 's/^.*\///'`
 tag_date=`date +%Y-%m-%d"T"%H:%M:%SZ`
+
 echo "Shutting down server named $nb_server_name in namespace $NB_NAMESPACE with date tag $tag_date."
 kubectl annotate notebook/$nb_server_name kubeflow-resource-stopped=$tag_date -n $NB_NAMESPACE
 echo "Command had return code $?."

--- a/output/remote-desktop/aaw-suspend-server.sh
+++ b/output/remote-desktop/aaw-suspend-server.sh
@@ -1,7 +1,19 @@
-#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
 #!/bin/bash
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/478
+
+time_wait=$1
+if ! [ ${time_wait:+1} ]
+then
+    time_wait=30
+fi
+
+echo "Waiting $time_wait seconds before shutting down server (press ctrl-c to stop shutdown)..."
+sleep $time_wait
+
 nb_server_name=`echo $NB_PREFIX | perl -pe 's/^.*\///'`
 tag_date=`date +%Y-%m-%d"T"%H:%M:%SZ`
+
 echo "Shutting down server named $nb_server_name in namespace $NB_NAMESPACE with date tag $tag_date."
 kubectl annotate notebook/$nb_server_name kubeflow-resource-stopped=$tag_date -n $NB_NAMESPACE
 echo "Command had return code $?."

--- a/output/rstudio/aaw-suspend-server.sh
+++ b/output/rstudio/aaw-suspend-server.sh
@@ -1,7 +1,19 @@
-#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
 #!/bin/bash
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/478
+
+time_wait=$1
+if ! [ ${time_wait:+1} ]
+then
+    time_wait=30
+fi
+
+echo "Waiting $time_wait seconds before shutting down server (press ctrl-c to stop shutdown)..."
+sleep $time_wait
+
 nb_server_name=`echo $NB_PREFIX | perl -pe 's/^.*\///'`
 tag_date=`date +%Y-%m-%d"T"%H:%M:%SZ`
+
 echo "Shutting down server named $nb_server_name in namespace $NB_NAMESPACE with date tag $tag_date."
 kubectl annotate notebook/$nb_server_name kubeflow-resource-stopped=$tag_date -n $NB_NAMESPACE
 echo "Command had return code $?."

--- a/output/sas/aaw-suspend-server.sh
+++ b/output/sas/aaw-suspend-server.sh
@@ -1,7 +1,19 @@
-#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
 #!/bin/bash
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/478
+
+time_wait=$1
+if ! [ ${time_wait:+1} ]
+then
+    time_wait=30
+fi
+
+echo "Waiting $time_wait seconds before shutting down server (press ctrl-c to stop shutdown)..."
+sleep $time_wait
+
 nb_server_name=`echo $NB_PREFIX | perl -pe 's/^.*\///'`
 tag_date=`date +%Y-%m-%d"T"%H:%M:%SZ`
+
 echo "Shutting down server named $nb_server_name in namespace $NB_NAMESPACE with date tag $tag_date."
 kubectl annotate notebook/$nb_server_name kubeflow-resource-stopped=$tag_date -n $NB_NAMESPACE
 echo "Command had return code $?."

--- a/resources/common/aaw-suspend-server.sh
+++ b/resources/common/aaw-suspend-server.sh
@@ -1,7 +1,19 @@
-#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
 #!/bin/bash
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/459
+#https://github.com/StatCan/aaw-kubeflow-containers/issues/478
+
+time_wait=$1
+if ! [ ${time_wait:+1} ]
+then
+    time_wait=30
+fi
+
+echo "Waiting $time_wait seconds before shutting down server (press ctrl-c to stop shutdown)..."
+sleep $time_wait
+
 nb_server_name=`echo $NB_PREFIX | perl -pe 's/^.*\///'`
 tag_date=`date +%Y-%m-%d"T"%H:%M:%SZ`
+
 echo "Shutting down server named $nb_server_name in namespace $NB_NAMESPACE with date tag $tag_date."
 kubectl annotate notebook/$nb_server_name kubeflow-resource-stopped=$tag_date -n $NB_NAMESPACE
 echo "Command had return code $?."

--- a/scripts/aaw-suspend-server.sh
+++ b/scripts/aaw-suspend-server.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-nb_server_name=`echo $NB_PREFIX | perl -pe 's/^.*\///'`
-tag_date=`date +%Y-%m-%d"T"%H:%M:%SZ`
-echo "Shutting down server named $nb_server_name in namespace $NB_NAMESPACE with date tag $tag_date."
-kubectl annotate notebook/$nb_server_name kubeflow-resource-stopped=$tag_date -n $NB_NAMESPACE
-echo "Command had return code $?."


### PR DESCRIPTION
# Description

**What your PR adds/fixes/removes**
Closes https://github.com/StatCan/aaw-kubeflow-containers/issues/478
Removes an extra suspend script that I think we added by accident in https://github.com/StatCan/aaw-kubeflow-containers/pull/467/files, it was not used in that pr, nor is it used in the docker-bits

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [x] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?


