### PR TITLE
Update build_push.yaml: deprecate set-output

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -110,7 +110,7 @@ jobs:
       id: notebook-name
       shell: bash
       run: |
-        echo "${{ NOTEBOOK_NAME }}=${{ matrix.notebook }}" >> $GITHUB_OUTPUT
+        echo ${{ steps.notebook-name.outputs.NOTEBOOK_NAME }}=${{ matrix.notebook }} >> $GITHUB_OUTPUT
 
     # Connect to Azure Container registry (ACR)
     - uses: azure/docker-login@v1

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -110,7 +110,7 @@ jobs:
       id: notebook-name
       shell: bash
       run: |
-        echo "{NOTEBOOK_NAME}={matrix.notebook}" >> $GITHUB_OUTPUT
+        echo "${{ steps.notebook-name.outputs.NOTEBOOK_NAME }}=${{ matrix.notebook }}" >> $GITHUB_OUTPUT
 
     # Connect to Azure Container registry (ACR)
     - uses: azure/docker-login@v1

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -110,7 +110,7 @@ jobs:
       id: notebook-name
       shell: bash
       run: |
-        echo ${{ steps.notebook-name.outputs.NOTEBOOK_NAME }}=${{ matrix.notebook }} >> $GITHUB_OUTPUT
+        echo ${{ env.NOTEBOOK_NAME }}=${{ matrix.notebook }} >> $GITHUB_OUTPUT
 
     # Connect to Azure Container registry (ACR)
     - uses: azure/docker-login@v1

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -110,7 +110,7 @@ jobs:
       id: notebook-name
       shell: bash
       run: |
-        echo "${{ NOTEBOOK_NAME }}=${{ matrix.notebook }}" >> $GITHUB_OUTPUT
+        echo "{NOTEBOOK_NAME}={matrix.notebook}" >> $GITHUB_OUTPUT
 
     # Connect to Azure Container registry (ACR)
     - uses: azure/docker-login@v1

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -110,7 +110,7 @@ jobs:
       id: notebook-name
       shell: bash
       run: |
-        echo ${{ env.NOTEBOOK_NAME }}=${{ matrix.notebook }} >> $GITHUB_OUTPUT
+        echo NOTEBOOK_NAME=${{ matrix.notebook }} >> $GITHUB_OUTPUT
 
     # Connect to Azure Container registry (ACR)
     - uses: azure/docker-login@v1

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -110,7 +110,7 @@ jobs:
       id: notebook-name
       shell: bash
       run: |
-        echo "${{ steps.notebook-name.outputs.NOTEBOOK_NAME }}=${{ matrix.notebook }}" >> $GITHUB_OUTPUT
+        echo "${{ NOTEBOOK_NAME }}=${{ matrix.notebook }}" >> $GITHUB_OUTPUT
 
     # Connect to Azure Container registry (ACR)
     - uses: azure/docker-login@v1

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -110,7 +110,7 @@ jobs:
       id: notebook-name
       shell: bash
       run: |
-        echo ::set-output name=NOTEBOOK_NAME::${{ matrix.notebook }}
+        echo "${{ NOTEBOOK_NAME }}=${{ matrix.notebook }}" >> $GITHUB_OUTPUT
 
     # Connect to Azure Container registry (ACR)
     - uses: azure/docker-login@v1
@@ -183,7 +183,7 @@ jobs:
           github.event_name == 'pull_request' &&
           contains( github.event.pull_request.labels.*.name, 'auto-deploy')
         )
-      run: echo "::set-output name=boolean::true"
+      run: echo 'boolean=true' >> $GITHUB_OUTPUT
 
     # Pull the local image back, then "build" it (will just tag the pulled image)
     - name: Pull image back from local repo

--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,9 @@ build/%: ## build the latest image
 	docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
-	echo full_image_name=$$IMAGE_NAME >> $GITHUB_OUTPUT && \
-	echo image_tag=$(TAG) && \
-	echo image_repo=$${REPO}
+	echo "::set-output name=full_image_name::$$IMAGE_NAME" && \
+	echo "::set-output name=image_tag::$(TAG)" && \
+	echo "::set-output name=image_repo::$${REPO}"
 
 post-build/%: export REPO?=$(DEFAULT_REPO)
 post-build/%: export TAG?=$(DEFAULT_TAG)

--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,9 @@ build/%: ## build the latest image
 	docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
-	echo "::set-output name=full_image_name::$$IMAGE_NAME" && \
-	echo "::set-output name=image_tag::$(TAG)" && \
-	echo "::set-output name=image_repo::$${REPO}"
+	echo full_image_name=$$IMAGE_NAME >> $GITHUB_OUTPUT && \
+	echo image_tag=$(TAG) && \
+	echo image_repo=$${REPO}
 
 post-build/%: export REPO?=$(DEFAULT_REPO)
 post-build/%: export TAG?=$(DEFAULT_TAG)

--- a/make_helpers/get_branch_name.sh
+++ b/make_helpers/get_branch_name.sh
@@ -21,7 +21,6 @@ if [[ $GITHUB_ACTIONS == "true" ]] ; then
 		BRANCH_NAME=""
 	fi
 
-	# echo "::set-output name=branch_name::$BRANCH_NAME"
 else
 	BRANCH_NAME=`git rev-parse --abbrev-ref HEAD`
 fi


### PR DESCRIPTION
update workflow to use $GITHUB_OUTPUT instead of set-output.

See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
