### PR TITLE
update set-output to GITHUB_OUTPUT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,9 @@ build/%: ## build the latest image
 	docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
-	echo "full_image_name=$$IMAGE_NAME" >> $GITHUB_OUTPUT && \
-	echo "image_tag=$(TAG)" >> $GITHUB_OUTPUT && \
-	echo "image_repo=${REPO}" >> $GITHUB_OUTPUT
+	echo "full_image_name=$$IMAGE_NAME >> $GITHUB_OUTPUT" && \
+	echo "image_tag=$(TAG) >> $GITHUB_OUTPUT" && \
+	echo "image_repo=${REPO} >> $GITHUB_OUTPUT"
 
 post-build/%: export REPO?=$(DEFAULT_REPO)
 post-build/%: export TAG?=$(DEFAULT_TAG)

--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,9 @@ build/%: ## build the latest image
 	docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
-	echo "full_image_name=$$IMAGE_NAME >> $GITHUB_OUTPUT" && \
-	echo "image_tag=$(TAG) >> $GITHUB_OUTPUT" && \
-	echo "image_repo=${REPO} >> $GITHUB_OUTPUT"
+	echo "full_image_name=$$IMAGE_NAME" >> $(GITHUB_OUTPUT) && \
+	echo "image_tag=$(TAG)" >> $(GITHUB_OUTPUT) && \
+	echo "image_repo=${REPO}" >> $(GITHUB_OUTPUT)
 
 post-build/%: export REPO?=$(DEFAULT_REPO)
 post-build/%: export TAG?=$(DEFAULT_TAG)

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ build/%: ## build the latest image
 	# End repo with exactly one trailing slash, unless it is empty
 	REPO=$$(echo "$(REPO)" | sed 's:/*$$:/:' | sed 's:^\s*/*\s*$$::') &&\
 	IMAGE_NAME="$${REPO}$(notdir $@):$(TAG)" && \
-	docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
+	DOCKER_BUILDKIT=0 docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
 	echo "full_image_name=$$IMAGE_NAME" >> $(GITHUB_OUTPUT) && \

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ build/%: ## build the latest image
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
 	echo "full_image_name=$$IMAGE_NAME" >> $(GITHUB_OUTPUT) && \
 	echo "image_tag=$(TAG)" >> $(GITHUB_OUTPUT) && \
-	echo "image_repo=${REPO}" >> $(GITHUB_OUTPUT)
+	echo "image_repo=$${REPO}" >> $(GITHUB_OUTPUT)
 
 post-build/%: export REPO?=$(DEFAULT_REPO)
 post-build/%: export TAG?=$(DEFAULT_TAG)

--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,9 @@ build/%: ## build the latest image
 	docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
-	echo "::set-output name=full_image_name::$$IMAGE_NAME" && \
-	echo "::set-output name=image_tag::$(TAG)" && \
-	echo "::set-output name=image_repo::$${REPO}"
+	echo "full_image_name=$$IMAGE_NAME" >> $GITHUB_OUTPUT && \
+	echo "image_tag=$(TAG)" >> $GITHUB_OUTPUT && \
+	echo "image_repo=${REPO}" >> $GITHUB_OUTPUT
 
 post-build/%: export REPO?=$(DEFAULT_REPO)
 post-build/%: export TAG?=$(DEFAULT_TAG)


### PR DESCRIPTION
Previously I [deprecated set-output for the Github Actions](https://github.com/StatCan/aaw-kubeflow-containers/pull/491), this PR is for deprecating set-output in the Makefile. 
