### PR TITLE
Update Makefile: add DOCKER_BUILDKIT=0 to docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ build/%: ## build the latest image
 	# End repo with exactly one trailing slash, unless it is empty
 	REPO=$$(echo "$(REPO)" | sed 's:/*$$:/:' | sed 's:^\s*/*\s*$$::') &&\
 	IMAGE_NAME="$${REPO}$(notdir $@):$(TAG)" && \
-	docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
+	DOCKER_BUILDKIT=0 docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
 	echo "::set-output name=full_image_name::$$IMAGE_NAME" && \


### PR DESCRIPTION
@vexingly discovered the version of Docker that Github Actions uses was updated right before our builds started failing.

### Runner

For the successful builds before August 04th 2023, we have the following image version:

```
Runner Image
  Image: ubuntu-22.04
  Version: 20230724.1.0
  Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20230724.1/images/linux/Ubuntu2204-Readme.md
```

And when the builds started failing, we have a new version of the runner (still based on Ubuntu 22.04):

```
Image: ubuntu-22.04
  Version: 20230728.3.0
  Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20230728.3/images/linux/Ubuntu2204-Readme.md
```

### Docker

For the older, successful runs:

```
Checking docker version
  /usr/bin/docker version --format '{{.Server.APIVersion}}'
  '1.41'
  Docker daemon API version: '1.41'
  /usr/bin/docker version --format '{{.Client.APIVersion}}'
  '1.41'
  Docker client API version: '1.41'
```

The newer, failed runs:

```
Checking docker version
  /usr/bin/docker version --format '{{.Server.APIVersion}}'
  '1.42'
  Docker daemon API version: '1.42'
  /usr/bin/docker version --format '{{.Client.APIVersion}}'
  '1.42'
  Docker client API version: '1.42'
```

### Docker Engine API Changes

The changelog (https://docs.docker.com/engine/api/version-history/) included the following entry which gave @vexingly the insight to try rolling back the builder to the previous version.

> `GET /_ping` and `HEAD /_ping` now return Builder-Version by default. This header contains the default builder to use, and is a recommendation as advertised by the daemon. However, it is up to the client to choose which builder to use.
> The default value on Linux is version “2” (BuildKit), but the daemon can be configured to recommend version “1” (classic Builder). Windows does not yet support BuildKit for native Windows images, and uses “1” (classic builder) as a default.
> This change is not versioned, and affects all API versions if the daemon has this patch.

## Resolution

Add `DOCKER_BUILDKIT=0` to `docker build` command in the `Makefile` to disable BuildKit, 

`DOCKER_BUILDKIT=0 docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@)`