### PR TITLE
Jupyterlab openmpp poc (#518)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ DEFAULT_NB_PREFIX := /notebook/username/notebookname
 
 .PHONY: clean .output generate-dockerfiles
 
+
 clean:
 	rm -rf $(OUT) $(TMP)
 

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -121,6 +121,35 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
+# OpenM install
+# Install OpenM++ MPI
+ARG OMPP_VERSION="1.15.4"
+# IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
+ARG OMPP_PKG_DATE="20230803"
+ARG SHA256ompp=5da79984ef67ad16b3b7d429896b8a553930ca46a16079aaef24b3c9dc867956
+# OpenM++ environment settings
+ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
+
+# OpenM++ expects sqlite to be installed (not just libsqlite)
+RUN apt-get install --yes sqlite3 \
+    && wget -q https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_debian_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
+    && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
+    && mkdir -p ${OMPP_INSTALL_DIR} \
+    && tar -xf /tmp/ompp.tar.gz -C ${OMPP_INSTALL_DIR} --strip-components=1
+    
+# Customize and rebuild omp-ui for jupyter-ompp-proxy install
+# issue with making a relative publicPath https://github.com/quasarframework/quasar/issues/8513
+RUN sed -i -e 's/history/hash/' ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && sed -i -e "s/OMS_URL:.*''/OMS_URL: '.'/" ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && npm install --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
+    && npm run build --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
+    && rm -r ${OMPP_INSTALL_DIR}/html \
+    && mv ${OMPP_INSTALL_DIR}/ompp-ui/dist/spa ${OMPP_INSTALL_DIR}/html \
+    && fix-permissions ${OMPP_INSTALL_DIR}
+
+COPY jupyter-ompp-proxy/ /opt/jupyter-ompp-proxy/
+RUN pip install /opt/jupyter-ompp-proxy/
+
 # Solarized Theme and Cell Execution Time
 COPY jupyterlab-overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json
 

--- a/docker-bits/∞_CMD.Dockerfile
+++ b/docker-bits/∞_CMD.Dockerfile
@@ -6,6 +6,9 @@ EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
 COPY mc-tenant-wrapper.sh /usr/local/bin/mc
 COPY trino-wrapper.sh /usr/local/bin/trino
+COPY start-oms.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/start-oms.sh
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/docker-bits/∞_CMD_remote-desktop.Dockerfile
+++ b/docker-bits/∞_CMD_remote-desktop.Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 8888
 COPY start-remote-desktop.sh /usr/local/bin/
 COPY mc-tenant-wrapper.sh /usr/local/bin/mc
 COPY trino-wrapper.sh /usr/local/bin/trino
+
 RUN chmod +x /usr/local/bin/trino
 RUN chsh -s /bin/bash $NB_USER
 

--- a/output/docker-stacks-datascience-notebook/Dockerfile
+++ b/output/docker-stacks-datascience-notebook/Dockerfile
@@ -12,6 +12,9 @@ EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
 COPY mc-tenant-wrapper.sh /usr/local/bin/mc
 COPY trino-wrapper.sh /usr/local/bin/trino
+COPY start-oms.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/start-oms.sh
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/docker-stacks-datascience-notebook/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
+++ b/output/docker-stacks-datascience-notebook/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
@@ -1,0 +1,30 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
+
+def setup_ompp():
+
+  def _get_cmd():
+
+    return [
+      "bash",
+      "-c",
+      "/usr/local/bin/start-oms.sh"
+    ]
+
+  def _rewrite_response(response):
+    if 'Location' in response.headers:
+      response.headers['Location'] = response.headers['Location'].replace('/SASStudio', os.environ.get('NB_PREFIX') + '/sasstudio/SASStudio')
+
+  return {
+    "command": _get_cmd,
+    "timeout": 60,
+    "port": 4040,
+    "launcher_entry": {
+      "title": "OpenM++",
+            "icon_path": os.path.join(os.getenv("OMPP_INSTALL_DIR", None), "html", "icons", "openmpp.svg"),
+    },
+    "rewrite_response": _rewrite_response,
+  }

--- a/output/docker-stacks-datascience-notebook/jupyter-ompp-proxy/setup.py
+++ b/output/docker-stacks-datascience-notebook/jupyter-ompp-proxy/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+setuptools.setup(
+    name="jupyter-ompp-proxy",
+    version='0.0.1',
+    url="https://github.com/StatCan/jupyter-ompp-proxy",
+    author="Her Majesty The Queen In Right of Canada",
+    description="Jupyter extension to proxy OpenM++ webui",
+    packages=setuptools.find_packages(),
+	keywords=['SAS'],
+	classifiers=['Framework :: Jupyter'],
+    install_requires=[
+        'jupyter-server-proxy>=3.2.0'
+    ],
+    entry_points={
+        'jupyter_serverproxy_servers': [
+            'ompp = jupyter_ompp_proxy:setup_ompp'
+        ]
+    },
+    # package_data={
+    #     'jupyter_sasstudio_proxy': ['icons/sasstudio.svg'],
+    # },
+)

--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -151,6 +151,14 @@ if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
   conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-pytorch-remote 
 fi
 
+# Copy default ompp models on first start up
+export OMS_MODELS_DIR="/home/jovyan/models"
+if [ ! -d "$OMS_MODELS_DIR" ]; then
+  echo "Creating ompp default model directory"
+  mkdir -p "$OMS_MODELS_DIR"
+  cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODELS_DIR"
+fi
+
 echo "--------------------starting jupyter--------------------"
 
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \

--- a/output/docker-stacks-datascience-notebook/start-oms.sh
+++ b/output/docker-stacks-datascience-notebook/start-oms.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# It does:
+#   ulimit -S -s 65536
+#   OM_ROOT=${OM_ROOT} bin/oms -oms.Listen http://localhost:${OMS_PORT} -oms.HomeDir models/home -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+#
+# Environment:
+#   OM_ROOT  - openM++ root folder, default: current directory
+#   OMS_PORT - oms web-service port to listen, default: 4040
+
+# set -e
+set -m
+
+# large models may require stack limit increase
+#
+ulimit -S -s 65536
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  echo "FAILED to set: ulimit -S -s 65536"
+  echo -n "Press Enter to exit..."
+  read any
+  exit $status
+fi
+
+# set openM++ root folder 
+#
+self=$(basename $0)
+
+OM_ROOT="$OMPP_INSTALL_DIR"
+
+[ "$OM_ROOT" != "$PWD" ] && pushd $OM_ROOT
+
+# allow to use $MODEL_NAME.ini file in UI for model run
+#
+export OM_CFG_INI_ALLOW=true
+export OM_CFG_INI_ANY_KEY=true
+export OMS_URL=${JUPYTER_SERVER_URL}ompp
+
+# OpenM++ default configuraton
+if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
+  #DEV
+  export OMS_MODEL_DIR=/home/jovyan/models
+  export OMS_HOME_DIR=/home/jovyan/
+else
+  if [ -d "/etc/protb" ]; then
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/
+  else
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/
+  fi
+fi
+
+# start oms web-service
+#
+[ -z "$OMS_PORT" ] && OMS_PORT=4040
+
+echo "OM_ROOT=$OM_ROOT"
+echo "OMS_PORT=$OMS_PORT"
+echo "OMS_URL=$OMS_URL"
+
+echo "OMS_MODEL_DIR=$OMS_MODEL_DIR"
+if [ ! -d $OMS_MODEL_DIR ]; then
+  mkdir -p $OMS_MODEL_DIR
+fi
+
+echo "OMS_HOME_DIR=$OMS_HOME_DIR"
+if [ ! -d $OMS_HOME_DIR ]; then
+  mkdir -p $OMS_HOME_DIR
+fi
+
+OM_ROOT=$OM_ROOT ./bin/oms -l localhost:${OMS_PORT} -oms.ModelDir ${OMS_MODEL_DIR} -oms.HomeDir ${OMS_HOME_DIR} -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  [ $status -eq 130 ] && echo " oms web-service terminated by Ctrl+C"
+  [ $status -ne 130 ] && echo " FAILED to start oms web-service"
+fi
+
+echo "."
+echo -n "Press Enter to exit..."
+read any
+exit $status

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -291,6 +291,35 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
+# OpenM install
+# Install OpenM++ MPI
+ARG OMPP_VERSION="1.15.4"
+# IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
+ARG OMPP_PKG_DATE="20230803"
+ARG SHA256ompp=5da79984ef67ad16b3b7d429896b8a553930ca46a16079aaef24b3c9dc867956
+# OpenM++ environment settings
+ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
+
+# OpenM++ expects sqlite to be installed (not just libsqlite)
+RUN apt-get install --yes sqlite3 \
+    && wget -q https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_debian_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
+    && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
+    && mkdir -p ${OMPP_INSTALL_DIR} \
+    && tar -xf /tmp/ompp.tar.gz -C ${OMPP_INSTALL_DIR} --strip-components=1
+    
+# Customize and rebuild omp-ui for jupyter-ompp-proxy install
+# issue with making a relative publicPath https://github.com/quasarframework/quasar/issues/8513
+RUN sed -i -e 's/history/hash/' ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && sed -i -e "s/OMS_URL:.*''/OMS_URL: '.'/" ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && npm install --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
+    && npm run build --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
+    && rm -r ${OMPP_INSTALL_DIR}/html \
+    && mv ${OMPP_INSTALL_DIR}/ompp-ui/dist/spa ${OMPP_INSTALL_DIR}/html \
+    && fix-permissions ${OMPP_INSTALL_DIR}
+
+COPY jupyter-ompp-proxy/ /opt/jupyter-ompp-proxy/
+RUN pip install /opt/jupyter-ompp-proxy/
+
 # Solarized Theme and Cell Execution Time
 COPY jupyterlab-overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json
 
@@ -365,6 +394,9 @@ EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
 COPY mc-tenant-wrapper.sh /usr/local/bin/mc
 COPY trino-wrapper.sh /usr/local/bin/trino
+COPY start-oms.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/start-oms.sh
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/jupyterlab-cpu/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
+++ b/output/jupyterlab-cpu/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
@@ -1,0 +1,30 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
+
+def setup_ompp():
+
+  def _get_cmd():
+
+    return [
+      "bash",
+      "-c",
+      "/usr/local/bin/start-oms.sh"
+    ]
+
+  def _rewrite_response(response):
+    if 'Location' in response.headers:
+      response.headers['Location'] = response.headers['Location'].replace('/SASStudio', os.environ.get('NB_PREFIX') + '/sasstudio/SASStudio')
+
+  return {
+    "command": _get_cmd,
+    "timeout": 60,
+    "port": 4040,
+    "launcher_entry": {
+      "title": "OpenM++",
+            "icon_path": os.path.join(os.getenv("OMPP_INSTALL_DIR", None), "html", "icons", "openmpp.svg"),
+    },
+    "rewrite_response": _rewrite_response,
+  }

--- a/output/jupyterlab-cpu/jupyter-ompp-proxy/setup.py
+++ b/output/jupyterlab-cpu/jupyter-ompp-proxy/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+setuptools.setup(
+    name="jupyter-ompp-proxy",
+    version='0.0.1',
+    url="https://github.com/StatCan/jupyter-ompp-proxy",
+    author="Her Majesty The Queen In Right of Canada",
+    description="Jupyter extension to proxy OpenM++ webui",
+    packages=setuptools.find_packages(),
+	keywords=['SAS'],
+	classifiers=['Framework :: Jupyter'],
+    install_requires=[
+        'jupyter-server-proxy>=3.2.0'
+    ],
+    entry_points={
+        'jupyter_serverproxy_servers': [
+            'ompp = jupyter_ompp_proxy:setup_ompp'
+        ]
+    },
+    # package_data={
+    #     'jupyter_sasstudio_proxy': ['icons/sasstudio.svg'],
+    # },
+)

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -151,6 +151,14 @@ if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
   conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-pytorch-remote 
 fi
 
+# Copy default ompp models on first start up
+export OMS_MODELS_DIR="/home/jovyan/models"
+if [ ! -d "$OMS_MODELS_DIR" ]; then
+  echo "Creating ompp default model directory"
+  mkdir -p "$OMS_MODELS_DIR"
+  cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODELS_DIR"
+fi
+
 echo "--------------------starting jupyter--------------------"
 
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \

--- a/output/jupyterlab-cpu/start-oms.sh
+++ b/output/jupyterlab-cpu/start-oms.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# It does:
+#   ulimit -S -s 65536
+#   OM_ROOT=${OM_ROOT} bin/oms -oms.Listen http://localhost:${OMS_PORT} -oms.HomeDir models/home -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+#
+# Environment:
+#   OM_ROOT  - openM++ root folder, default: current directory
+#   OMS_PORT - oms web-service port to listen, default: 4040
+
+# set -e
+set -m
+
+# large models may require stack limit increase
+#
+ulimit -S -s 65536
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  echo "FAILED to set: ulimit -S -s 65536"
+  echo -n "Press Enter to exit..."
+  read any
+  exit $status
+fi
+
+# set openM++ root folder 
+#
+self=$(basename $0)
+
+OM_ROOT="$OMPP_INSTALL_DIR"
+
+[ "$OM_ROOT" != "$PWD" ] && pushd $OM_ROOT
+
+# allow to use $MODEL_NAME.ini file in UI for model run
+#
+export OM_CFG_INI_ALLOW=true
+export OM_CFG_INI_ANY_KEY=true
+export OMS_URL=${JUPYTER_SERVER_URL}ompp
+
+# OpenM++ default configuraton
+if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
+  #DEV
+  export OMS_MODEL_DIR=/home/jovyan/models
+  export OMS_HOME_DIR=/home/jovyan/
+else
+  if [ -d "/etc/protb" ]; then
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/
+  else
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/
+  fi
+fi
+
+# start oms web-service
+#
+[ -z "$OMS_PORT" ] && OMS_PORT=4040
+
+echo "OM_ROOT=$OM_ROOT"
+echo "OMS_PORT=$OMS_PORT"
+echo "OMS_URL=$OMS_URL"
+
+echo "OMS_MODEL_DIR=$OMS_MODEL_DIR"
+if [ ! -d $OMS_MODEL_DIR ]; then
+  mkdir -p $OMS_MODEL_DIR
+fi
+
+echo "OMS_HOME_DIR=$OMS_HOME_DIR"
+if [ ! -d $OMS_HOME_DIR ]; then
+  mkdir -p $OMS_HOME_DIR
+fi
+
+OM_ROOT=$OM_ROOT ./bin/oms -l localhost:${OMS_PORT} -oms.ModelDir ${OMS_MODEL_DIR} -oms.HomeDir ${OMS_HOME_DIR} -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  [ $status -eq 130 ] && echo " oms web-service terminated by Ctrl+C"
+  [ $status -ne 130 ] && echo " FAILED to start oms web-service"
+fi
+
+echo "."
+echo -n "Press Enter to exit..."
+read any
+exit $status

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -421,6 +421,35 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
+# OpenM install
+# Install OpenM++ MPI
+ARG OMPP_VERSION="1.15.4"
+# IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
+ARG OMPP_PKG_DATE="20230803"
+ARG SHA256ompp=5da79984ef67ad16b3b7d429896b8a553930ca46a16079aaef24b3c9dc867956
+# OpenM++ environment settings
+ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
+
+# OpenM++ expects sqlite to be installed (not just libsqlite)
+RUN apt-get install --yes sqlite3 \
+    && wget -q https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_debian_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
+    && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
+    && mkdir -p ${OMPP_INSTALL_DIR} \
+    && tar -xf /tmp/ompp.tar.gz -C ${OMPP_INSTALL_DIR} --strip-components=1
+    
+# Customize and rebuild omp-ui for jupyter-ompp-proxy install
+# issue with making a relative publicPath https://github.com/quasarframework/quasar/issues/8513
+RUN sed -i -e 's/history/hash/' ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && sed -i -e "s/OMS_URL:.*''/OMS_URL: '.'/" ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && npm install --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
+    && npm run build --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
+    && rm -r ${OMPP_INSTALL_DIR}/html \
+    && mv ${OMPP_INSTALL_DIR}/ompp-ui/dist/spa ${OMPP_INSTALL_DIR}/html \
+    && fix-permissions ${OMPP_INSTALL_DIR}
+
+COPY jupyter-ompp-proxy/ /opt/jupyter-ompp-proxy/
+RUN pip install /opt/jupyter-ompp-proxy/
+
 # Solarized Theme and Cell Execution Time
 COPY jupyterlab-overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json
 
@@ -495,6 +524,9 @@ EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
 COPY mc-tenant-wrapper.sh /usr/local/bin/mc
 COPY trino-wrapper.sh /usr/local/bin/trino
+COPY start-oms.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/start-oms.sh
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/jupyterlab-pytorch/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
+++ b/output/jupyterlab-pytorch/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
@@ -1,0 +1,30 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
+
+def setup_ompp():
+
+  def _get_cmd():
+
+    return [
+      "bash",
+      "-c",
+      "/usr/local/bin/start-oms.sh"
+    ]
+
+  def _rewrite_response(response):
+    if 'Location' in response.headers:
+      response.headers['Location'] = response.headers['Location'].replace('/SASStudio', os.environ.get('NB_PREFIX') + '/sasstudio/SASStudio')
+
+  return {
+    "command": _get_cmd,
+    "timeout": 60,
+    "port": 4040,
+    "launcher_entry": {
+      "title": "OpenM++",
+            "icon_path": os.path.join(os.getenv("OMPP_INSTALL_DIR", None), "html", "icons", "openmpp.svg"),
+    },
+    "rewrite_response": _rewrite_response,
+  }

--- a/output/jupyterlab-pytorch/jupyter-ompp-proxy/setup.py
+++ b/output/jupyterlab-pytorch/jupyter-ompp-proxy/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+setuptools.setup(
+    name="jupyter-ompp-proxy",
+    version='0.0.1',
+    url="https://github.com/StatCan/jupyter-ompp-proxy",
+    author="Her Majesty The Queen In Right of Canada",
+    description="Jupyter extension to proxy OpenM++ webui",
+    packages=setuptools.find_packages(),
+	keywords=['SAS'],
+	classifiers=['Framework :: Jupyter'],
+    install_requires=[
+        'jupyter-server-proxy>=3.2.0'
+    ],
+    entry_points={
+        'jupyter_serverproxy_servers': [
+            'ompp = jupyter_ompp_proxy:setup_ompp'
+        ]
+    },
+    # package_data={
+    #     'jupyter_sasstudio_proxy': ['icons/sasstudio.svg'],
+    # },
+)

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -151,6 +151,14 @@ if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
   conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-pytorch-remote 
 fi
 
+# Copy default ompp models on first start up
+export OMS_MODELS_DIR="/home/jovyan/models"
+if [ ! -d "$OMS_MODELS_DIR" ]; then
+  echo "Creating ompp default model directory"
+  mkdir -p "$OMS_MODELS_DIR"
+  cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODELS_DIR"
+fi
+
 echo "--------------------starting jupyter--------------------"
 
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \

--- a/output/jupyterlab-pytorch/start-oms.sh
+++ b/output/jupyterlab-pytorch/start-oms.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# It does:
+#   ulimit -S -s 65536
+#   OM_ROOT=${OM_ROOT} bin/oms -oms.Listen http://localhost:${OMS_PORT} -oms.HomeDir models/home -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+#
+# Environment:
+#   OM_ROOT  - openM++ root folder, default: current directory
+#   OMS_PORT - oms web-service port to listen, default: 4040
+
+# set -e
+set -m
+
+# large models may require stack limit increase
+#
+ulimit -S -s 65536
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  echo "FAILED to set: ulimit -S -s 65536"
+  echo -n "Press Enter to exit..."
+  read any
+  exit $status
+fi
+
+# set openM++ root folder 
+#
+self=$(basename $0)
+
+OM_ROOT="$OMPP_INSTALL_DIR"
+
+[ "$OM_ROOT" != "$PWD" ] && pushd $OM_ROOT
+
+# allow to use $MODEL_NAME.ini file in UI for model run
+#
+export OM_CFG_INI_ALLOW=true
+export OM_CFG_INI_ANY_KEY=true
+export OMS_URL=${JUPYTER_SERVER_URL}ompp
+
+# OpenM++ default configuraton
+if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
+  #DEV
+  export OMS_MODEL_DIR=/home/jovyan/models
+  export OMS_HOME_DIR=/home/jovyan/
+else
+  if [ -d "/etc/protb" ]; then
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/
+  else
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/
+  fi
+fi
+
+# start oms web-service
+#
+[ -z "$OMS_PORT" ] && OMS_PORT=4040
+
+echo "OM_ROOT=$OM_ROOT"
+echo "OMS_PORT=$OMS_PORT"
+echo "OMS_URL=$OMS_URL"
+
+echo "OMS_MODEL_DIR=$OMS_MODEL_DIR"
+if [ ! -d $OMS_MODEL_DIR ]; then
+  mkdir -p $OMS_MODEL_DIR
+fi
+
+echo "OMS_HOME_DIR=$OMS_HOME_DIR"
+if [ ! -d $OMS_HOME_DIR ]; then
+  mkdir -p $OMS_HOME_DIR
+fi
+
+OM_ROOT=$OM_ROOT ./bin/oms -l localhost:${OMS_PORT} -oms.ModelDir ${OMS_MODEL_DIR} -oms.HomeDir ${OMS_HOME_DIR} -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  [ $status -eq 130 ] && echo " oms web-service terminated by Ctrl+C"
+  [ $status -ne 130 ] && echo " FAILED to start oms web-service"
+fi
+
+echo "."
+echo -n "Press Enter to exit..."
+read any
+exit $status

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -418,6 +418,35 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
+# OpenM install
+# Install OpenM++ MPI
+ARG OMPP_VERSION="1.15.4"
+# IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
+ARG OMPP_PKG_DATE="20230803"
+ARG SHA256ompp=5da79984ef67ad16b3b7d429896b8a553930ca46a16079aaef24b3c9dc867956
+# OpenM++ environment settings
+ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
+
+# OpenM++ expects sqlite to be installed (not just libsqlite)
+RUN apt-get install --yes sqlite3 \
+    && wget -q https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_debian_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
+    && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
+    && mkdir -p ${OMPP_INSTALL_DIR} \
+    && tar -xf /tmp/ompp.tar.gz -C ${OMPP_INSTALL_DIR} --strip-components=1
+    
+# Customize and rebuild omp-ui for jupyter-ompp-proxy install
+# issue with making a relative publicPath https://github.com/quasarframework/quasar/issues/8513
+RUN sed -i -e 's/history/hash/' ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && sed -i -e "s/OMS_URL:.*''/OMS_URL: '.'/" ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && npm install --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
+    && npm run build --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
+    && rm -r ${OMPP_INSTALL_DIR}/html \
+    && mv ${OMPP_INSTALL_DIR}/ompp-ui/dist/spa ${OMPP_INSTALL_DIR}/html \
+    && fix-permissions ${OMPP_INSTALL_DIR}
+
+COPY jupyter-ompp-proxy/ /opt/jupyter-ompp-proxy/
+RUN pip install /opt/jupyter-ompp-proxy/
+
 # Solarized Theme and Cell Execution Time
 COPY jupyterlab-overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json
 
@@ -492,6 +521,9 @@ EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
 COPY mc-tenant-wrapper.sh /usr/local/bin/mc
 COPY trino-wrapper.sh /usr/local/bin/trino
+COPY start-oms.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/start-oms.sh
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/jupyterlab-tensorflow/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
+++ b/output/jupyterlab-tensorflow/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
@@ -1,0 +1,30 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
+
+def setup_ompp():
+
+  def _get_cmd():
+
+    return [
+      "bash",
+      "-c",
+      "/usr/local/bin/start-oms.sh"
+    ]
+
+  def _rewrite_response(response):
+    if 'Location' in response.headers:
+      response.headers['Location'] = response.headers['Location'].replace('/SASStudio', os.environ.get('NB_PREFIX') + '/sasstudio/SASStudio')
+
+  return {
+    "command": _get_cmd,
+    "timeout": 60,
+    "port": 4040,
+    "launcher_entry": {
+      "title": "OpenM++",
+            "icon_path": os.path.join(os.getenv("OMPP_INSTALL_DIR", None), "html", "icons", "openmpp.svg"),
+    },
+    "rewrite_response": _rewrite_response,
+  }

--- a/output/jupyterlab-tensorflow/jupyter-ompp-proxy/setup.py
+++ b/output/jupyterlab-tensorflow/jupyter-ompp-proxy/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+setuptools.setup(
+    name="jupyter-ompp-proxy",
+    version='0.0.1',
+    url="https://github.com/StatCan/jupyter-ompp-proxy",
+    author="Her Majesty The Queen In Right of Canada",
+    description="Jupyter extension to proxy OpenM++ webui",
+    packages=setuptools.find_packages(),
+	keywords=['SAS'],
+	classifiers=['Framework :: Jupyter'],
+    install_requires=[
+        'jupyter-server-proxy>=3.2.0'
+    ],
+    entry_points={
+        'jupyter_serverproxy_servers': [
+            'ompp = jupyter_ompp_proxy:setup_ompp'
+        ]
+    },
+    # package_data={
+    #     'jupyter_sasstudio_proxy': ['icons/sasstudio.svg'],
+    # },
+)

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -151,6 +151,14 @@ if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
   conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-pytorch-remote 
 fi
 
+# Copy default ompp models on first start up
+export OMS_MODELS_DIR="/home/jovyan/models"
+if [ ! -d "$OMS_MODELS_DIR" ]; then
+  echo "Creating ompp default model directory"
+  mkdir -p "$OMS_MODELS_DIR"
+  cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODELS_DIR"
+fi
+
 echo "--------------------starting jupyter--------------------"
 
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \

--- a/output/jupyterlab-tensorflow/start-oms.sh
+++ b/output/jupyterlab-tensorflow/start-oms.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# It does:
+#   ulimit -S -s 65536
+#   OM_ROOT=${OM_ROOT} bin/oms -oms.Listen http://localhost:${OMS_PORT} -oms.HomeDir models/home -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+#
+# Environment:
+#   OM_ROOT  - openM++ root folder, default: current directory
+#   OMS_PORT - oms web-service port to listen, default: 4040
+
+# set -e
+set -m
+
+# large models may require stack limit increase
+#
+ulimit -S -s 65536
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  echo "FAILED to set: ulimit -S -s 65536"
+  echo -n "Press Enter to exit..."
+  read any
+  exit $status
+fi
+
+# set openM++ root folder 
+#
+self=$(basename $0)
+
+OM_ROOT="$OMPP_INSTALL_DIR"
+
+[ "$OM_ROOT" != "$PWD" ] && pushd $OM_ROOT
+
+# allow to use $MODEL_NAME.ini file in UI for model run
+#
+export OM_CFG_INI_ALLOW=true
+export OM_CFG_INI_ANY_KEY=true
+export OMS_URL=${JUPYTER_SERVER_URL}ompp
+
+# OpenM++ default configuraton
+if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
+  #DEV
+  export OMS_MODEL_DIR=/home/jovyan/models
+  export OMS_HOME_DIR=/home/jovyan/
+else
+  if [ -d "/etc/protb" ]; then
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/
+  else
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/
+  fi
+fi
+
+# start oms web-service
+#
+[ -z "$OMS_PORT" ] && OMS_PORT=4040
+
+echo "OM_ROOT=$OM_ROOT"
+echo "OMS_PORT=$OMS_PORT"
+echo "OMS_URL=$OMS_URL"
+
+echo "OMS_MODEL_DIR=$OMS_MODEL_DIR"
+if [ ! -d $OMS_MODEL_DIR ]; then
+  mkdir -p $OMS_MODEL_DIR
+fi
+
+echo "OMS_HOME_DIR=$OMS_HOME_DIR"
+if [ ! -d $OMS_HOME_DIR ]; then
+  mkdir -p $OMS_HOME_DIR
+fi
+
+OM_ROOT=$OM_ROOT ./bin/oms -l localhost:${OMS_PORT} -oms.ModelDir ${OMS_MODEL_DIR} -oms.HomeDir ${OMS_HOME_DIR} -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  [ $status -eq 130 ] && echo " oms web-service terminated by Ctrl+C"
+  [ $status -ne 130 ] && echo " FAILED to start oms web-service"
+fi
+
+echo "."
+echo -n "Press Enter to exit..."
+read any
+exit $status

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -623,6 +623,7 @@ EXPOSE 8888
 COPY start-remote-desktop.sh /usr/local/bin/
 COPY mc-tenant-wrapper.sh /usr/local/bin/mc
 COPY trino-wrapper.sh /usr/local/bin/trino
+
 RUN chmod +x /usr/local/bin/trino
 RUN chsh -s /bin/bash $NB_USER
 

--- a/output/remote-desktop/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
+++ b/output/remote-desktop/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
@@ -1,0 +1,30 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
+
+def setup_ompp():
+
+  def _get_cmd():
+
+    return [
+      "bash",
+      "-c",
+      "/usr/local/bin/start-oms.sh"
+    ]
+
+  def _rewrite_response(response):
+    if 'Location' in response.headers:
+      response.headers['Location'] = response.headers['Location'].replace('/SASStudio', os.environ.get('NB_PREFIX') + '/sasstudio/SASStudio')
+
+  return {
+    "command": _get_cmd,
+    "timeout": 60,
+    "port": 4040,
+    "launcher_entry": {
+      "title": "OpenM++",
+            "icon_path": os.path.join(os.getenv("OMPP_INSTALL_DIR", None), "html", "icons", "openmpp.svg"),
+    },
+    "rewrite_response": _rewrite_response,
+  }

--- a/output/remote-desktop/jupyter-ompp-proxy/setup.py
+++ b/output/remote-desktop/jupyter-ompp-proxy/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+setuptools.setup(
+    name="jupyter-ompp-proxy",
+    version='0.0.1',
+    url="https://github.com/StatCan/jupyter-ompp-proxy",
+    author="Her Majesty The Queen In Right of Canada",
+    description="Jupyter extension to proxy OpenM++ webui",
+    packages=setuptools.find_packages(),
+	keywords=['SAS'],
+	classifiers=['Framework :: Jupyter'],
+    install_requires=[
+        'jupyter-server-proxy>=3.2.0'
+    ],
+    entry_points={
+        'jupyter_serverproxy_servers': [
+            'ompp = jupyter_ompp_proxy:setup_ompp'
+        ]
+    },
+    # package_data={
+    #     'jupyter_sasstudio_proxy': ['icons/sasstudio.svg'],
+    # },
+)

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -151,6 +151,14 @@ if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
   conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-pytorch-remote 
 fi
 
+# Copy default ompp models on first start up
+export OMS_MODELS_DIR="/home/jovyan/models"
+if [ ! -d "$OMS_MODELS_DIR" ]; then
+  echo "Creating ompp default model directory"
+  mkdir -p "$OMS_MODELS_DIR"
+  cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODELS_DIR"
+fi
+
 echo "--------------------starting jupyter--------------------"
 
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \

--- a/output/remote-desktop/start-oms.sh
+++ b/output/remote-desktop/start-oms.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# It does:
+#   ulimit -S -s 65536
+#   OM_ROOT=${OM_ROOT} bin/oms -oms.Listen http://localhost:${OMS_PORT} -oms.HomeDir models/home -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+#
+# Environment:
+#   OM_ROOT  - openM++ root folder, default: current directory
+#   OMS_PORT - oms web-service port to listen, default: 4040
+
+# set -e
+set -m
+
+# large models may require stack limit increase
+#
+ulimit -S -s 65536
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  echo "FAILED to set: ulimit -S -s 65536"
+  echo -n "Press Enter to exit..."
+  read any
+  exit $status
+fi
+
+# set openM++ root folder 
+#
+self=$(basename $0)
+
+OM_ROOT="$OMPP_INSTALL_DIR"
+
+[ "$OM_ROOT" != "$PWD" ] && pushd $OM_ROOT
+
+# allow to use $MODEL_NAME.ini file in UI for model run
+#
+export OM_CFG_INI_ALLOW=true
+export OM_CFG_INI_ANY_KEY=true
+export OMS_URL=${JUPYTER_SERVER_URL}ompp
+
+# OpenM++ default configuraton
+if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
+  #DEV
+  export OMS_MODEL_DIR=/home/jovyan/models
+  export OMS_HOME_DIR=/home/jovyan/
+else
+  if [ -d "/etc/protb" ]; then
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/
+  else
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/
+  fi
+fi
+
+# start oms web-service
+#
+[ -z "$OMS_PORT" ] && OMS_PORT=4040
+
+echo "OM_ROOT=$OM_ROOT"
+echo "OMS_PORT=$OMS_PORT"
+echo "OMS_URL=$OMS_URL"
+
+echo "OMS_MODEL_DIR=$OMS_MODEL_DIR"
+if [ ! -d $OMS_MODEL_DIR ]; then
+  mkdir -p $OMS_MODEL_DIR
+fi
+
+echo "OMS_HOME_DIR=$OMS_HOME_DIR"
+if [ ! -d $OMS_HOME_DIR ]; then
+  mkdir -p $OMS_HOME_DIR
+fi
+
+OM_ROOT=$OM_ROOT ./bin/oms -l localhost:${OMS_PORT} -oms.ModelDir ${OMS_MODEL_DIR} -oms.HomeDir ${OMS_HOME_DIR} -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  [ $status -eq 130 ] && echo " oms web-service terminated by Ctrl+C"
+  [ $status -ne 130 ] && echo " FAILED to start oms web-service"
+fi
+
+echo "."
+echo -n "Press Enter to exit..."
+read any
+exit $status

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -260,6 +260,9 @@ EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
 COPY mc-tenant-wrapper.sh /usr/local/bin/mc
 COPY trino-wrapper.sh /usr/local/bin/trino
+COPY start-oms.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/start-oms.sh
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/rstudio/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
+++ b/output/rstudio/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
@@ -1,0 +1,30 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
+
+def setup_ompp():
+
+  def _get_cmd():
+
+    return [
+      "bash",
+      "-c",
+      "/usr/local/bin/start-oms.sh"
+    ]
+
+  def _rewrite_response(response):
+    if 'Location' in response.headers:
+      response.headers['Location'] = response.headers['Location'].replace('/SASStudio', os.environ.get('NB_PREFIX') + '/sasstudio/SASStudio')
+
+  return {
+    "command": _get_cmd,
+    "timeout": 60,
+    "port": 4040,
+    "launcher_entry": {
+      "title": "OpenM++",
+            "icon_path": os.path.join(os.getenv("OMPP_INSTALL_DIR", None), "html", "icons", "openmpp.svg"),
+    },
+    "rewrite_response": _rewrite_response,
+  }

--- a/output/rstudio/jupyter-ompp-proxy/setup.py
+++ b/output/rstudio/jupyter-ompp-proxy/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+setuptools.setup(
+    name="jupyter-ompp-proxy",
+    version='0.0.1',
+    url="https://github.com/StatCan/jupyter-ompp-proxy",
+    author="Her Majesty The Queen In Right of Canada",
+    description="Jupyter extension to proxy OpenM++ webui",
+    packages=setuptools.find_packages(),
+	keywords=['SAS'],
+	classifiers=['Framework :: Jupyter'],
+    install_requires=[
+        'jupyter-server-proxy>=3.2.0'
+    ],
+    entry_points={
+        'jupyter_serverproxy_servers': [
+            'ompp = jupyter_ompp_proxy:setup_ompp'
+        ]
+    },
+    # package_data={
+    #     'jupyter_sasstudio_proxy': ['icons/sasstudio.svg'],
+    # },
+)

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -151,6 +151,14 @@ if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
   conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-pytorch-remote 
 fi
 
+# Copy default ompp models on first start up
+export OMS_MODELS_DIR="/home/jovyan/models"
+if [ ! -d "$OMS_MODELS_DIR" ]; then
+  echo "Creating ompp default model directory"
+  mkdir -p "$OMS_MODELS_DIR"
+  cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODELS_DIR"
+fi
+
 echo "--------------------starting jupyter--------------------"
 
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \

--- a/output/rstudio/start-oms.sh
+++ b/output/rstudio/start-oms.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# It does:
+#   ulimit -S -s 65536
+#   OM_ROOT=${OM_ROOT} bin/oms -oms.Listen http://localhost:${OMS_PORT} -oms.HomeDir models/home -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+#
+# Environment:
+#   OM_ROOT  - openM++ root folder, default: current directory
+#   OMS_PORT - oms web-service port to listen, default: 4040
+
+# set -e
+set -m
+
+# large models may require stack limit increase
+#
+ulimit -S -s 65536
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  echo "FAILED to set: ulimit -S -s 65536"
+  echo -n "Press Enter to exit..."
+  read any
+  exit $status
+fi
+
+# set openM++ root folder 
+#
+self=$(basename $0)
+
+OM_ROOT="$OMPP_INSTALL_DIR"
+
+[ "$OM_ROOT" != "$PWD" ] && pushd $OM_ROOT
+
+# allow to use $MODEL_NAME.ini file in UI for model run
+#
+export OM_CFG_INI_ALLOW=true
+export OM_CFG_INI_ANY_KEY=true
+export OMS_URL=${JUPYTER_SERVER_URL}ompp
+
+# OpenM++ default configuraton
+if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
+  #DEV
+  export OMS_MODEL_DIR=/home/jovyan/models
+  export OMS_HOME_DIR=/home/jovyan/
+else
+  if [ -d "/etc/protb" ]; then
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/
+  else
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/
+  fi
+fi
+
+# start oms web-service
+#
+[ -z "$OMS_PORT" ] && OMS_PORT=4040
+
+echo "OM_ROOT=$OM_ROOT"
+echo "OMS_PORT=$OMS_PORT"
+echo "OMS_URL=$OMS_URL"
+
+echo "OMS_MODEL_DIR=$OMS_MODEL_DIR"
+if [ ! -d $OMS_MODEL_DIR ]; then
+  mkdir -p $OMS_MODEL_DIR
+fi
+
+echo "OMS_HOME_DIR=$OMS_HOME_DIR"
+if [ ! -d $OMS_HOME_DIR ]; then
+  mkdir -p $OMS_HOME_DIR
+fi
+
+OM_ROOT=$OM_ROOT ./bin/oms -l localhost:${OMS_PORT} -oms.ModelDir ${OMS_MODEL_DIR} -oms.HomeDir ${OMS_HOME_DIR} -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  [ $status -eq 130 ] && echo " oms web-service terminated by Ctrl+C"
+  [ $status -ne 130 ] && echo " FAILED to start oms web-service"
+fi
+
+echo "."
+echo -n "Press Enter to exit..."
+read any
+exit $status

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -288,6 +288,35 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
+# OpenM install
+# Install OpenM++ MPI
+ARG OMPP_VERSION="1.15.4"
+# IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
+ARG OMPP_PKG_DATE="20230803"
+ARG SHA256ompp=5da79984ef67ad16b3b7d429896b8a553930ca46a16079aaef24b3c9dc867956
+# OpenM++ environment settings
+ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
+
+# OpenM++ expects sqlite to be installed (not just libsqlite)
+RUN apt-get install --yes sqlite3 \
+    && wget -q https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_debian_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
+    && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
+    && mkdir -p ${OMPP_INSTALL_DIR} \
+    && tar -xf /tmp/ompp.tar.gz -C ${OMPP_INSTALL_DIR} --strip-components=1
+    
+# Customize and rebuild omp-ui for jupyter-ompp-proxy install
+# issue with making a relative publicPath https://github.com/quasarframework/quasar/issues/8513
+RUN sed -i -e 's/history/hash/' ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && sed -i -e "s/OMS_URL:.*''/OMS_URL: '.'/" ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && npm install --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
+    && npm run build --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
+    && rm -r ${OMPP_INSTALL_DIR}/html \
+    && mv ${OMPP_INSTALL_DIR}/ompp-ui/dist/spa ${OMPP_INSTALL_DIR}/html \
+    && fix-permissions ${OMPP_INSTALL_DIR}
+
+COPY jupyter-ompp-proxy/ /opt/jupyter-ompp-proxy/
+RUN pip install /opt/jupyter-ompp-proxy/
+
 # Solarized Theme and Cell Execution Time
 COPY jupyterlab-overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json
 
@@ -468,6 +497,9 @@ EXPOSE 8888
 COPY start-custom.sh /usr/local/bin/
 COPY mc-tenant-wrapper.sh /usr/local/bin/mc
 COPY trino-wrapper.sh /usr/local/bin/trino
+COPY start-oms.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/start-oms.sh
 
 # Add --user to all pip install calls and point pip to Artifactory repository
 COPY pip.conf /tmp/pip.conf

--- a/output/sas/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
+++ b/output/sas/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
@@ -1,0 +1,30 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
+
+def setup_ompp():
+
+  def _get_cmd():
+
+    return [
+      "bash",
+      "-c",
+      "/usr/local/bin/start-oms.sh"
+    ]
+
+  def _rewrite_response(response):
+    if 'Location' in response.headers:
+      response.headers['Location'] = response.headers['Location'].replace('/SASStudio', os.environ.get('NB_PREFIX') + '/sasstudio/SASStudio')
+
+  return {
+    "command": _get_cmd,
+    "timeout": 60,
+    "port": 4040,
+    "launcher_entry": {
+      "title": "OpenM++",
+            "icon_path": os.path.join(os.getenv("OMPP_INSTALL_DIR", None), "html", "icons", "openmpp.svg"),
+    },
+    "rewrite_response": _rewrite_response,
+  }

--- a/output/sas/jupyter-ompp-proxy/setup.py
+++ b/output/sas/jupyter-ompp-proxy/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+setuptools.setup(
+    name="jupyter-ompp-proxy",
+    version='0.0.1',
+    url="https://github.com/StatCan/jupyter-ompp-proxy",
+    author="Her Majesty The Queen In Right of Canada",
+    description="Jupyter extension to proxy OpenM++ webui",
+    packages=setuptools.find_packages(),
+	keywords=['SAS'],
+	classifiers=['Framework :: Jupyter'],
+    install_requires=[
+        'jupyter-server-proxy>=3.2.0'
+    ],
+    entry_points={
+        'jupyter_serverproxy_servers': [
+            'ompp = jupyter_ompp_proxy:setup_ompp'
+        ]
+    },
+    # package_data={
+    #     'jupyter_sasstudio_proxy': ['icons/sasstudio.svg'],
+    # },
+)

--- a/output/sas/start-custom.sh
+++ b/output/sas/start-custom.sh
@@ -151,6 +151,14 @@ if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
   conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-pytorch-remote 
 fi
 
+# Copy default ompp models on first start up
+export OMS_MODELS_DIR="/home/jovyan/models"
+if [ ! -d "$OMS_MODELS_DIR" ]; then
+  echo "Creating ompp default model directory"
+  mkdir -p "$OMS_MODELS_DIR"
+  cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODELS_DIR"
+fi
+
 echo "--------------------starting jupyter--------------------"
 
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \

--- a/output/sas/start-oms.sh
+++ b/output/sas/start-oms.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# It does:
+#   ulimit -S -s 65536
+#   OM_ROOT=${OM_ROOT} bin/oms -oms.Listen http://localhost:${OMS_PORT} -oms.HomeDir models/home -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+#
+# Environment:
+#   OM_ROOT  - openM++ root folder, default: current directory
+#   OMS_PORT - oms web-service port to listen, default: 4040
+
+# set -e
+set -m
+
+# large models may require stack limit increase
+#
+ulimit -S -s 65536
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  echo "FAILED to set: ulimit -S -s 65536"
+  echo -n "Press Enter to exit..."
+  read any
+  exit $status
+fi
+
+# set openM++ root folder 
+#
+self=$(basename $0)
+
+OM_ROOT="$OMPP_INSTALL_DIR"
+
+[ "$OM_ROOT" != "$PWD" ] && pushd $OM_ROOT
+
+# allow to use $MODEL_NAME.ini file in UI for model run
+#
+export OM_CFG_INI_ALLOW=true
+export OM_CFG_INI_ANY_KEY=true
+export OMS_URL=${JUPYTER_SERVER_URL}ompp
+
+# OpenM++ default configuraton
+if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
+  #DEV
+  export OMS_MODEL_DIR=/home/jovyan/models
+  export OMS_HOME_DIR=/home/jovyan/
+else
+  if [ -d "/etc/protb" ]; then
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/
+  else
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/
+  fi
+fi
+
+# start oms web-service
+#
+[ -z "$OMS_PORT" ] && OMS_PORT=4040
+
+echo "OM_ROOT=$OM_ROOT"
+echo "OMS_PORT=$OMS_PORT"
+echo "OMS_URL=$OMS_URL"
+
+echo "OMS_MODEL_DIR=$OMS_MODEL_DIR"
+if [ ! -d $OMS_MODEL_DIR ]; then
+  mkdir -p $OMS_MODEL_DIR
+fi
+
+echo "OMS_HOME_DIR=$OMS_HOME_DIR"
+if [ ! -d $OMS_HOME_DIR ]; then
+  mkdir -p $OMS_HOME_DIR
+fi
+
+OM_ROOT=$OM_ROOT ./bin/oms -l localhost:${OMS_PORT} -oms.ModelDir ${OMS_MODEL_DIR} -oms.HomeDir ${OMS_HOME_DIR} -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  [ $status -eq 130 ] && echo " oms web-service terminated by Ctrl+C"
+  [ $status -ne 130 ] && echo " FAILED to start oms web-service"
+fi
+
+echo "."
+echo -n "Press Enter to exit..."
+read any
+exit $status

--- a/resources/common/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
+++ b/resources/common/jupyter-ompp-proxy/jupyter_ompp_proxy/__init__.py
@@ -1,0 +1,30 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
+
+def setup_ompp():
+
+  def _get_cmd():
+
+    return [
+      "bash",
+      "-c",
+      "/usr/local/bin/start-oms.sh"
+    ]
+
+  def _rewrite_response(response):
+    if 'Location' in response.headers:
+      response.headers['Location'] = response.headers['Location'].replace('/SASStudio', os.environ.get('NB_PREFIX') + '/sasstudio/SASStudio')
+
+  return {
+    "command": _get_cmd,
+    "timeout": 60,
+    "port": 4040,
+    "launcher_entry": {
+      "title": "OpenM++",
+            "icon_path": os.path.join(os.getenv("OMPP_INSTALL_DIR", None), "html", "icons", "openmpp.svg"),
+    },
+    "rewrite_response": _rewrite_response,
+  }

--- a/resources/common/jupyter-ompp-proxy/setup.py
+++ b/resources/common/jupyter-ompp-proxy/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+setuptools.setup(
+    name="jupyter-ompp-proxy",
+    version='0.0.1',
+    url="https://github.com/StatCan/jupyter-ompp-proxy",
+    author="Her Majesty The Queen In Right of Canada",
+    description="Jupyter extension to proxy OpenM++ webui",
+    packages=setuptools.find_packages(),
+	keywords=['SAS'],
+	classifiers=['Framework :: Jupyter'],
+    install_requires=[
+        'jupyter-server-proxy>=3.2.0'
+    ],
+    entry_points={
+        'jupyter_serverproxy_servers': [
+            'ompp = jupyter_ompp_proxy:setup_ompp'
+        ]
+    },
+    # package_data={
+    #     'jupyter_sasstudio_proxy': ['icons/sasstudio.svg'],
+    # },
+)

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -151,6 +151,14 @@ if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
   conda config --add channels https://jfrog.aaw.cloud.statcan.ca/artifactory/api/conda/conda-pytorch-remote 
 fi
 
+# Copy default ompp models on first start up
+export OMS_MODELS_DIR="/home/jovyan/models"
+if [ ! -d "$OMS_MODELS_DIR" ]; then
+  echo "Creating ompp default model directory"
+  mkdir -p "$OMS_MODELS_DIR"
+  cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODELS_DIR"
+fi
+
 echo "--------------------starting jupyter--------------------"
 
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \

--- a/resources/common/start-oms.sh
+++ b/resources/common/start-oms.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# It does:
+#   ulimit -S -s 65536
+#   OM_ROOT=${OM_ROOT} bin/oms -oms.Listen http://localhost:${OMS_PORT} -oms.HomeDir models/home -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+#
+# Environment:
+#   OM_ROOT  - openM++ root folder, default: current directory
+#   OMS_PORT - oms web-service port to listen, default: 4040
+
+# set -e
+set -m
+
+# large models may require stack limit increase
+#
+ulimit -S -s 65536
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  echo "FAILED to set: ulimit -S -s 65536"
+  echo -n "Press Enter to exit..."
+  read any
+  exit $status
+fi
+
+# set openM++ root folder 
+#
+self=$(basename $0)
+
+OM_ROOT="$OMPP_INSTALL_DIR"
+
+[ "$OM_ROOT" != "$PWD" ] && pushd $OM_ROOT
+
+# allow to use $MODEL_NAME.ini file in UI for model run
+#
+export OM_CFG_INI_ALLOW=true
+export OM_CFG_INI_ANY_KEY=true
+export OMS_URL=${JUPYTER_SERVER_URL}ompp
+
+# OpenM++ default configuraton
+if [[ "$KUBERNETES_SERVICE_HOST" =~ ".131." ]]; then
+  #DEV
+  export OMS_MODEL_DIR=/home/jovyan/models
+  export OMS_HOME_DIR=/home/jovyan/
+else
+  if [ -d "/etc/protb" ]; then
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-protected-b/microsim/
+  else
+    export OMS_MODEL_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/models
+    export OMS_HOME_DIR=/home/jovyan/buckets/aaw-unclassified/microsim/
+  fi
+fi
+
+# start oms web-service
+#
+[ -z "$OMS_PORT" ] && OMS_PORT=4040
+
+echo "OM_ROOT=$OM_ROOT"
+echo "OMS_PORT=$OMS_PORT"
+echo "OMS_URL=$OMS_URL"
+
+echo "OMS_MODEL_DIR=$OMS_MODEL_DIR"
+if [ ! -d $OMS_MODEL_DIR ]; then
+  mkdir -p $OMS_MODEL_DIR
+fi
+
+echo "OMS_HOME_DIR=$OMS_HOME_DIR"
+if [ ! -d $OMS_HOME_DIR ]; then
+  mkdir -p $OMS_HOME_DIR
+fi
+
+OM_ROOT=$OM_ROOT ./bin/oms -l localhost:${OMS_PORT} -oms.ModelDir ${OMS_MODEL_DIR} -oms.HomeDir ${OMS_HOME_DIR} -oms.AllowDownload -oms.AllowUpload -oms.AllowMicrodata -oms.LogRequest
+status=$?
+
+if [ $status -ne 0 ] ;
+then
+  [ $status -eq 130 ] && echo " oms web-service terminated by Ctrl+C"
+  [ $status -ne 130 ] && echo " FAILED to start oms web-service"
+fi
+
+echo "."
+echo -n "Press Enter to exit..."
+read any
+exit $status


### PR DESCRIPTION
* feat: install openmpp as jupyterlab service

* fix: generate dockerfiles

* chore: trigger auto-deploy

* fix: copy oms startup script

* fix: copy script in correct docker bit

* fix: make script executable

* fix: update openm version, fix config

* fix: sync issue

* fix: prepare openmpp config for prod deployment

* fix: move config to start-oms script

# Description

**What your PR adds/fixes/removes**

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
