### PR TITLE
fix(sas): update python version string

### DIFF
--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -48,7 +48,8 @@ ENV SASPY_VERSION="4.1.0"
 
 RUN pip install sas_kernel
 
-COPY sascfg.py /opt/conda/lib/python3.9/site-packages/saspy/sascfg.py
+# TODO: make Python version ENV var.
+COPY sascfg.py /opt/conda/lib/python3.11/site-packages/saspy/sascfg.py
 
 RUN jupyter nbextension install --py sas_kernel.showSASLog && \
     jupyter nbextension enable sas_kernel.showSASLog --py && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -427,7 +427,8 @@ ENV SASPY_VERSION="4.1.0"
 
 RUN pip install sas_kernel
 
-COPY sascfg.py /opt/conda/lib/python3.9/site-packages/saspy/sascfg.py
+# TODO: make Python version ENV var.
+COPY sascfg.py /opt/conda/lib/python3.11/site-packages/saspy/sascfg.py
 
 RUN jupyter nbextension install --py sas_kernel.showSASLog && \
     jupyter nbextension enable sas_kernel.showSASLog --py && \


### PR DESCRIPTION
This is to fix a bug introduced during the 22.04 upgrade.

The line 

```
COPY sascfg.py /opt/conda/lib/python3.9/site-packages/saspy/sascfg.py
```

Needed to be updated to `.../lib/python3.11/site-packages/...` to reflect the update to Python during the Ubuntu 22.04 upgrade.