### PR TITLE
update(saspy): SASPy 4.1.0 -> 5.4.0

### DIFF
--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -44,7 +44,7 @@ EXPOSE 8561 8591 38080
 
 # SASPY
 
-ENV SASPY_VERSION="4.1.0"
+ENV SASPY_VERSION="5.4.0"
 
 RUN pip install sas_kernel
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -423,7 +423,7 @@ EXPOSE 8561 8591 38080
 
 # SASPY
 
-ENV SASPY_VERSION="4.1.0"
+ENV SASPY_VERSION="5.4.0"
 
 RUN pip install sas_kernel
 


### PR DESCRIPTION
This is to update SASPy from 4.1.0 to 5.4.0 for compatibility with Python 3.11.


/closes https://github.com/StatCan/aaw-kubeflow-containers/issues/537