### PR TITLE
fix(pluto.jl): update base to 2023-12-25

### DIFF
--- a/docker-bits/0_cpu.Dockerfile
+++ b/docker-bits/0_cpu.Dockerfile
@@ -3,8 +3,9 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=2023-08-07
-FROM jupyter/datascience-notebook:$BASE_VERSION
+ARG BASE_VERSION=2023-12-25
+
+FROM quay.io/jupyter/datascience-notebook:$BASE_VERSION
 
 USER root
 

--- a/docker-bits/0_cpu_sas.Dockerfile
+++ b/docker-bits/0_cpu_sas.Dockerfile
@@ -3,10 +3,10 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=2023-08-07
+ARG BASE_VERSION=2023-12-25
 
 FROM k8scc01covidacr.azurecr.io/sas4c:0.0.3 as SASHome
-FROM jupyter/datascience-notebook:$BASE_VERSION
+FROM quay.io/jupyter/datascience-notebook:$BASE_VERSION
 
 USER root
 

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -60,9 +60,7 @@ RUN pip install \
     'ipympl' \
     'jupyter-server-proxy' \
     'jupyterlab-language-pack-fr-fr' \
-    # pinned version of package to fix dependency issues with jupyterlab v4
-    # remove pin when jupyterlab extensions are caught up to v4
-    'jupyterlab_execute_time==2.3.1' \
+    'jupyterlab_execute_time' \
     'nb_conda_kernels' \
     'jupyterlab-lsp' \
     'jupyter-lsp'  && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -13,8 +13,9 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=2023-08-07
-FROM jupyter/datascience-notebook:$BASE_VERSION
+ARG BASE_VERSION=2023-12-25
+
+FROM quay.io/jupyter/datascience-notebook:$BASE_VERSION
 
 USER root
 
@@ -212,9 +213,7 @@ RUN pip install \
     'ipympl' \
     'jupyter-server-proxy' \
     'jupyterlab-language-pack-fr-fr' \
-    # pinned version of package to fix dependency issues with jupyterlab v4
-    # remove pin when jupyterlab extensions are caught up to v4
-    'jupyterlab_execute_time==2.3.1' \
+    'jupyterlab_execute_time' \
     'nb_conda_kernels' \
     'jupyterlab-lsp' \
     'jupyter-lsp'  && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -13,8 +13,9 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=2023-08-07
-FROM jupyter/datascience-notebook:$BASE_VERSION
+ARG BASE_VERSION=2023-12-25
+
+FROM quay.io/jupyter/datascience-notebook:$BASE_VERSION
 
 USER root
 
@@ -234,9 +235,7 @@ RUN pip install \
     'ipympl' \
     'jupyter-server-proxy' \
     'jupyterlab-language-pack-fr-fr' \
-    # pinned version of package to fix dependency issues with jupyterlab v4
-    # remove pin when jupyterlab extensions are caught up to v4
-    'jupyterlab_execute_time==2.3.1' \
+    'jupyterlab_execute_time' \
     'nb_conda_kernels' \
     'jupyterlab-lsp' \
     'jupyter-lsp'  && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -13,8 +13,9 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=2023-08-07
-FROM jupyter/datascience-notebook:$BASE_VERSION
+ARG BASE_VERSION=2023-12-25
+
+FROM quay.io/jupyter/datascience-notebook:$BASE_VERSION
 
 USER root
 
@@ -341,9 +342,7 @@ RUN pip install \
     'ipympl' \
     'jupyter-server-proxy' \
     'jupyterlab-language-pack-fr-fr' \
-    # pinned version of package to fix dependency issues with jupyterlab v4
-    # remove pin when jupyterlab extensions are caught up to v4
-    'jupyterlab_execute_time==2.3.1' \
+    'jupyterlab_execute_time' \
     'nb_conda_kernels' \
     'jupyterlab-lsp' \
     'jupyter-lsp'  && \

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -13,8 +13,9 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=2023-08-07
-FROM jupyter/datascience-notebook:$BASE_VERSION
+ARG BASE_VERSION=2023-12-25
+
+FROM quay.io/jupyter/datascience-notebook:$BASE_VERSION
 
 USER root
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -8,10 +8,10 @@
 # It can be obtained by running `docker inspect repo/imagename:tag@digest` or from
 # https://github.com/jupyter/docker-stacks/wiki
 
-ARG BASE_VERSION=2023-08-07
+ARG BASE_VERSION=2023-12-25
 
 FROM k8scc01covidacr.azurecr.io/sas4c:0.0.3 as SASHome
-FROM jupyter/datascience-notebook:$BASE_VERSION
+FROM quay.io/jupyter/datascience-notebook:$BASE_VERSION
 
 USER root
 
@@ -214,9 +214,7 @@ RUN pip install \
     'ipympl' \
     'jupyter-server-proxy' \
     'jupyterlab-language-pack-fr-fr' \
-    # pinned version of package to fix dependency issues with jupyterlab v4
-    # remove pin when jupyterlab extensions are caught up to v4
-    'jupyterlab_execute_time==2.3.1' \
+    'jupyterlab_execute_time' \
     'nb_conda_kernels' \
     'jupyterlab-lsp' \
     'jupyter-lsp'  && \


### PR DESCRIPTION
I updated the base system to 2023-12-25.

NOTE: Images are hosted on https://quay.io/repository/jupyter/datascience-notebook from now on.

/closes #531 