### PR TITLE
Set wget as the default package downloader for RStudio.

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -86,14 +86,14 @@ jobs:
     - name: Set ENV variables for a PR containing the auto-deploy tag
       if: github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'auto-deploy')
       run: | 
-        echo "REGISTRY=k8scc01covidacrdev.azurecr.io" >> "$GITHUB_ENV"
-        echo "IMAGE_VERSION=dev" >> "$GITHUB_ENV"
+        echo "REGISTRY=k8scc01covidacr.azurecr.io" >> "$GITHUB_ENV"
+        echo "IMAGE_VERSION=test" >> "$GITHUB_ENV"
    
     - name: Set ENV variables for pushes to master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: | 
         echo "REGISTRY=k8scc01covidacr.azurecr.io" >> "$GITHUB_ENV"
-        echo "IMAGE_VERSION=v1" >> "$GITHUB_ENV"
+        echo "IMAGE_VERSION=test" >> "$GITHUB_ENV"
         echo "IS_LATEST=true" >> "$GITHUB_ENV"
 
     - uses: actions/checkout@master

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -86,14 +86,14 @@ jobs:
     - name: Set ENV variables for a PR containing the auto-deploy tag
       if: github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'auto-deploy')
       run: | 
-        echo "REGISTRY=k8scc01covidacr.azurecr.io" >> "$GITHUB_ENV"
-        echo "IMAGE_VERSION=test" >> "$GITHUB_ENV"
+        echo "REGISTRY=k8scc01covidacrdev.azurecr.io" >> "$GITHUB_ENV"
+        echo "IMAGE_VERSION=dev" >> "$GITHUB_ENV"
    
     - name: Set ENV variables for pushes to master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: | 
         echo "REGISTRY=k8scc01covidacr.azurecr.io" >> "$GITHUB_ENV"
-        echo "IMAGE_VERSION=test" >> "$GITHUB_ENV"
+        echo "IMAGE_VERSION=v1" >> "$GITHUB_ENV"
         echo "IS_LATEST=true" >> "$GITHUB_ENV"
 
     - uses: actions/checkout@master

--- a/output/jupyterlab-cpu/.Rprofile
+++ b/output/jupyterlab-cpu/.Rprofile
@@ -12,3 +12,7 @@ rm(package_dir)
 #-----------------------------
 #options(stringsAsFactors = FALSE)
 #options(prompt = "AAW> ")
+
+# using wget because https://github.com/StatCan/aaw-kubeflow-containers/issues/569
+# https://stackoverflow.com/questions/70559397/r-internet-routines-cannot-be-loaded-when-starting-from-rstudio
+options(download.file.method="wget")

--- a/output/jupyterlab-pytorch/.Rprofile
+++ b/output/jupyterlab-pytorch/.Rprofile
@@ -12,3 +12,7 @@ rm(package_dir)
 #-----------------------------
 #options(stringsAsFactors = FALSE)
 #options(prompt = "AAW> ")
+
+# using wget because https://github.com/StatCan/aaw-kubeflow-containers/issues/569
+# https://stackoverflow.com/questions/70559397/r-internet-routines-cannot-be-loaded-when-starting-from-rstudio
+options(download.file.method="wget")

--- a/output/jupyterlab-tensorflow/.Rprofile
+++ b/output/jupyterlab-tensorflow/.Rprofile
@@ -12,3 +12,7 @@ rm(package_dir)
 #-----------------------------
 #options(stringsAsFactors = FALSE)
 #options(prompt = "AAW> ")
+
+# using wget because https://github.com/StatCan/aaw-kubeflow-containers/issues/569
+# https://stackoverflow.com/questions/70559397/r-internet-routines-cannot-be-loaded-when-starting-from-rstudio
+options(download.file.method="wget")

--- a/output/remote-desktop/.Rprofile
+++ b/output/remote-desktop/.Rprofile
@@ -12,3 +12,7 @@ rm(package_dir)
 #-----------------------------
 #options(stringsAsFactors = FALSE)
 #options(prompt = "AAW> ")
+
+# using wget because https://github.com/StatCan/aaw-kubeflow-containers/issues/569
+# https://stackoverflow.com/questions/70559397/r-internet-routines-cannot-be-loaded-when-starting-from-rstudio
+options(download.file.method="wget")

--- a/output/rstudio/.Rprofile
+++ b/output/rstudio/.Rprofile
@@ -12,3 +12,7 @@ rm(package_dir)
 #-----------------------------
 #options(stringsAsFactors = FALSE)
 #options(prompt = "AAW> ")
+
+# using wget because https://github.com/StatCan/aaw-kubeflow-containers/issues/569
+# https://stackoverflow.com/questions/70559397/r-internet-routines-cannot-be-loaded-when-starting-from-rstudio
+options(download.file.method="wget")

--- a/output/sas/.Rprofile
+++ b/output/sas/.Rprofile
@@ -12,3 +12,7 @@ rm(package_dir)
 #-----------------------------
 #options(stringsAsFactors = FALSE)
 #options(prompt = "AAW> ")
+
+# using wget because https://github.com/StatCan/aaw-kubeflow-containers/issues/569
+# https://stackoverflow.com/questions/70559397/r-internet-routines-cannot-be-loaded-when-starting-from-rstudio
+options(download.file.method="wget")

--- a/resources/common/.Rprofile
+++ b/resources/common/.Rprofile
@@ -12,3 +12,7 @@ rm(package_dir)
 #-----------------------------
 #options(stringsAsFactors = FALSE)
 #options(prompt = "AAW> ")
+
+# using wget because https://github.com/StatCan/aaw-kubeflow-containers/issues/569
+# https://stackoverflow.com/questions/70559397/r-internet-routines-cannot-be-loaded-when-starting-from-rstudio
+options(download.file.method="wget")


### PR DESCRIPTION
@vexingly discovered `options(download.file.method="wget")` which can be added to `.Rprofile` which seems to fix the issue. As of this writing I am still unaware of what is causing the issue but this workaround fixes things for now.

### Reference

- https://stackoverflow.com/questions/70559397/r-internet-routines-cannot-be-loaded-when-starting-from-rstudio

### Result

After adding `options(download.file.method="wget")` to `.Rprofile` I am once again able to install packages using RStudio.