### PR TITLE
Ompp cleanup models

### DIFF
--- a/output/docker-stacks-datascience-notebook/start-oms.sh
+++ b/output/docker-stacks-datascience-notebook/start-oms.sh
@@ -66,7 +66,7 @@ if [ ! -d "$OMS_LOG_DIR" ]; then
 fi
 
 # Copy sample models from openmpp installation archive into models directory:
-cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
+# cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
 
 # These three environment variables don't persist so let's try using a file:
 echo "$OMS_HOME_DIR" > $OM_ROOT/etc/oms_home_dir 

--- a/output/jupyterlab-cpu/start-oms.sh
+++ b/output/jupyterlab-cpu/start-oms.sh
@@ -66,7 +66,7 @@ if [ ! -d "$OMS_LOG_DIR" ]; then
 fi
 
 # Copy sample models from openmpp installation archive into models directory:
-cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
+# cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
 
 # These three environment variables don't persist so let's try using a file:
 echo "$OMS_HOME_DIR" > $OM_ROOT/etc/oms_home_dir 

--- a/output/jupyterlab-pytorch/start-oms.sh
+++ b/output/jupyterlab-pytorch/start-oms.sh
@@ -66,7 +66,7 @@ if [ ! -d "$OMS_LOG_DIR" ]; then
 fi
 
 # Copy sample models from openmpp installation archive into models directory:
-cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
+# cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
 
 # These three environment variables don't persist so let's try using a file:
 echo "$OMS_HOME_DIR" > $OM_ROOT/etc/oms_home_dir 

--- a/output/jupyterlab-tensorflow/start-oms.sh
+++ b/output/jupyterlab-tensorflow/start-oms.sh
@@ -66,7 +66,7 @@ if [ ! -d "$OMS_LOG_DIR" ]; then
 fi
 
 # Copy sample models from openmpp installation archive into models directory:
-cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
+# cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
 
 # These three environment variables don't persist so let's try using a file:
 echo "$OMS_HOME_DIR" > $OM_ROOT/etc/oms_home_dir 

--- a/output/remote-desktop/start-oms.sh
+++ b/output/remote-desktop/start-oms.sh
@@ -66,7 +66,7 @@ if [ ! -d "$OMS_LOG_DIR" ]; then
 fi
 
 # Copy sample models from openmpp installation archive into models directory:
-cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
+# cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
 
 # These three environment variables don't persist so let's try using a file:
 echo "$OMS_HOME_DIR" > $OM_ROOT/etc/oms_home_dir 

--- a/output/rstudio/start-oms.sh
+++ b/output/rstudio/start-oms.sh
@@ -66,7 +66,7 @@ if [ ! -d "$OMS_LOG_DIR" ]; then
 fi
 
 # Copy sample models from openmpp installation archive into models directory:
-cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
+# cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
 
 # These three environment variables don't persist so let's try using a file:
 echo "$OMS_HOME_DIR" > $OM_ROOT/etc/oms_home_dir 

--- a/output/sas/start-oms.sh
+++ b/output/sas/start-oms.sh
@@ -66,7 +66,7 @@ if [ ! -d "$OMS_LOG_DIR" ]; then
 fi
 
 # Copy sample models from openmpp installation archive into models directory:
-cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
+# cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
 
 # These three environment variables don't persist so let's try using a file:
 echo "$OMS_HOME_DIR" > $OM_ROOT/etc/oms_home_dir 

--- a/resources/common/start-oms.sh
+++ b/resources/common/start-oms.sh
@@ -66,7 +66,7 @@ if [ ! -d "$OMS_LOG_DIR" ]; then
 fi
 
 # Copy sample models from openmpp installation archive into models directory:
-cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
+# cp -r "$OMPP_INSTALL_DIR/models/." "$OMS_MODEL_DIR"
 
 # These three environment variables don't persist so let's try using a file:
 echo "$OMS_HOME_DIR" > $OM_ROOT/etc/oms_home_dir 


### PR DESCRIPTION
No longer copying the sample models from the OMPP release to the buckets, this should also speed up the `start-oms.sh` script. If needed, those sample models can still be copied over manually. 