### PR TITLE
added pexpect tagged version to fix git push bug

### DIFF
--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -58,6 +58,7 @@ RUN pip install \
     'ipywidgets' \
     'markupsafe' \
     'ipympl' \
+    'pexpect==4.9.0' \
     'jupyter-server-proxy' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -211,6 +211,7 @@ RUN pip install \
     'ipywidgets' \
     'markupsafe' \
     'ipympl' \
+    'pexpect==4.9.0' \
     'jupyter-server-proxy' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -233,6 +233,7 @@ RUN pip install \
     'ipywidgets' \
     'markupsafe' \
     'ipympl' \
+    'pexpect==4.9.0' \
     'jupyter-server-proxy' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -340,6 +340,7 @@ RUN pip install \
     'ipywidgets' \
     'markupsafe' \
     'ipympl' \
+    'pexpect==4.9.0' \
     'jupyter-server-proxy' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -212,6 +212,7 @@ RUN pip install \
     'ipywidgets' \
     'markupsafe' \
     'ipympl' \
+    'pexpect==4.9.0' \
     'jupyter-server-proxy' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \


### PR DESCRIPTION
# Description

Fixes https://github.com/StatCan/aaw/issues/1945

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [x] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?
No but that is from master and is a known thing

## VS Code tests

- [x] Does VS Code open?
- [x] Can you install extensions?

## Code review

- [x] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?



TESTED ON k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:c56b5330f02d78387fa8af68d227e47800e20bb8
