### PR TITLE
chore(openmpp): bump to 1.16.1

### DIFF
--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -103,7 +103,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ARG OMPP_VERSION="1.15.6"
+ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="20231115"
 ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -103,10 +103,10 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ARG OMPP_VERSION="1.16.0"
+ARG OMPP_VERSION="1.16.1"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
+ARG OMPP_PKG_DATE="20240216"
+ARG SHA256ompp=e9036a187054a8fbba75a6b10c4ed7a48543dce3ee5a1c4a4380822806bc17b4
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -106,7 +106,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903
+ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -105,7 +105,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 # Install OpenM++ MPI
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20231115"
+ARG OMPP_PKG_DATE="20240213"
 ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -271,10 +271,10 @@ COPY minio-icon.png $RESOURCES_PATH/minio-icon.png
 COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 
 # Install OpenM++
-ENV OMPP_VERSION="1.16.0"
+ENV OMPP_VERSION="1.16.1"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ENV OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=d1c9f809c9d08de9a8c3411e593017873941a88b9ad4af74a04cb8e2f2982d72
+ENV OMPP_PKG_DATE="20240216"
+ARG SHA256ompp=8304f3fcb9e17dec5fad381673a8ecd1371d8827e2e8ce35431c4ec9acff4321
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -274,7 +274,7 @@ COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 ENV OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ENV OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=75372202c66f31c0b8d7c87967bdf7c75c300858841d10dad0b4230887de6856
+ARG SHA256ompp=d1c9f809c9d08de9a8c3411e593017873941a88b9ad4af74a04cb8e2f2982d72
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -271,7 +271,7 @@ COPY minio-icon.png $RESOURCES_PATH/minio-icon.png
 COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 
 # Install OpenM++
-ENV OMPP_VERSION="1.15.6"
+ENV OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ENV OMPP_PKG_DATE="20231115"
 ARG SHA256ompp=75372202c66f31c0b8d7c87967bdf7c75c300858841d10dad0b4230887de6856

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -273,7 +273,7 @@ COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 # Install OpenM++
 ENV OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ENV OMPP_PKG_DATE="20231115"
+ENV OMPP_PKG_DATE="20240213"
 ARG SHA256ompp=75372202c66f31c0b8d7c87967bdf7c75c300858841d10dad0b4230887de6856
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -258,7 +258,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 # Install OpenM++ MPI
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20241213"
+ARG OMPP_PKG_DATE="20240213"
 ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -259,7 +259,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="20241213"
-ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903
+ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -258,7 +258,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 # Install OpenM++ MPI
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20231115"
+ARG OMPP_PKG_DATE="20241213"
 ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -256,10 +256,10 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ARG OMPP_VERSION="1.16.0"
+ARG OMPP_VERSION="1.16.1"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
+ARG OMPP_PKG_DATE="20240216"
+ARG SHA256ompp=e9036a187054a8fbba75a6b10c4ed7a48543dce3ee5a1c4a4380822806bc17b4
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -256,7 +256,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ARG OMPP_VERSION="1.15.6"
+ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="20231115"
 ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -278,10 +278,10 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ARG OMPP_VERSION="1.16.0"
+ARG OMPP_VERSION="1.16.1"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
+ARG OMPP_PKG_DATE="20240216"
+ARG SHA256ompp=e9036a187054a8fbba75a6b10c4ed7a48543dce3ee5a1c4a4380822806bc17b4
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -278,7 +278,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ARG OMPP_VERSION="1.15.6"
+ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="20231115"
 ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -280,7 +280,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 # Install OpenM++ MPI
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20231115"
+ARG OMPP_PKG_DATE="20240213"
 ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -281,7 +281,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903
+ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -388,7 +388,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="202402135"
-ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903
+ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -387,7 +387,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 # Install OpenM++ MPI
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20231115"
+ARG OMPP_PKG_DATE="202402135"
 ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -385,7 +385,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ARG OMPP_VERSION="1.15.6"
+ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="20231115"
 ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -387,7 +387,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 # Install OpenM++ MPI
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="202402135"
+ARG OMPP_PKG_DATE="20240213"
 ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -385,10 +385,10 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ARG OMPP_VERSION="1.16.0"
+ARG OMPP_VERSION="1.16.1"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
+ARG SHA256ompp=e9036a187054a8fbba75a6b10c4ed7a48543dce3ee5a1c4a4380822806bc17b4
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -387,7 +387,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 # Install OpenM++ MPI
 ARG OMPP_VERSION="1.16.1"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20240213"
+ARG OMPP_PKG_DATE="20240216"
 ARG SHA256ompp=e9036a187054a8fbba75a6b10c4ed7a48543dce3ee5a1c4a4380822806bc17b4
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -489,7 +489,7 @@ COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 # Install OpenM++
 ENV OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ENV OMPP_PKG_DATE="20231115"
+ENV OMPP_PKG_DATE="20240213"
 ARG SHA256ompp=75372202c66f31c0b8d7c87967bdf7c75c300858841d10dad0b4230887de6856
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -487,7 +487,7 @@ COPY minio-icon.png $RESOURCES_PATH/minio-icon.png
 COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 
 # Install OpenM++
-ENV OMPP_VERSION="1.15.6"
+ENV OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ENV OMPP_PKG_DATE="20231115"
 ARG SHA256ompp=75372202c66f31c0b8d7c87967bdf7c75c300858841d10dad0b4230887de6856

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -487,10 +487,10 @@ COPY minio-icon.png $RESOURCES_PATH/minio-icon.png
 COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 
 # Install OpenM++
-ENV OMPP_VERSION="1.16.0"
+ENV OMPP_VERSION="1.16.1"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ENV OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=d1c9f809c9d08de9a8c3411e593017873941a88b9ad4af74a04cb8e2f2982d72
+ENV OMPP_PKG_DATE="20240216"
+ARG SHA256ompp=8304f3fcb9e17dec5fad381673a8ecd1371d8827e2e8ce35431c4ec9acff4321
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -490,7 +490,7 @@ COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 ENV OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ENV OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=75372202c66f31c0b8d7c87967bdf7c75c300858841d10dad0b4230887de6856
+ARG SHA256ompp=d1c9f809c9d08de9a8c3411e593017873941a88b9ad4af74a04cb8e2f2982d72
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100

--- a/output/remote-desktop/desktop-files/openmpp.desktop
+++ b/output/remote-desktop/desktop-files/openmpp.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=OpenM++
-Exec=/opt/openmpp/1.16.0/bin/ompp_ui_linux.sh
+Exec=/opt/openmpp/1.16.1/bin/ompp_ui_linux.sh
 Icon=/resources/openmpp.png
 Terminal=false
 Categories=Development;

--- a/output/remote-desktop/desktop-files/openmpp.desktop
+++ b/output/remote-desktop/desktop-files/openmpp.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=OpenM++
-Exec=/opt/openmpp/1.15.6/bin/ompp_ui_linux.sh
+Exec=/opt/openmpp/1.16.0/bin/ompp_ui_linux.sh
 Icon=/resources/openmpp.png
 Terminal=false
 Categories=Development;

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -257,7 +257,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ARG OMPP_VERSION="1.15.6"
+ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="20231115"
 ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -260,7 +260,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ARG OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903
+ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -259,7 +259,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 # Install OpenM++ MPI
 ARG OMPP_VERSION="1.16.0"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20231115"
+ARG OMPP_PKG_DATE="20240213"
 ARG SHA256ompp=ad8027e2097ed46205fe0e89c1008680e92c5de36af2613d0af8070e5c78b903
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -257,10 +257,10 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ARG OMPP_VERSION="1.16.0"
+ARG OMPP_VERSION="1.16.1"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ARG OMPP_PKG_DATE="20240213"
-ARG SHA256ompp=aadea55ab496186e8be49596753bcf2865fc822eb28388207c8809e13eb2b9a8
+ARG OMPP_PKG_DATE="20240216"
+ARG SHA256ompp=e9036a187054a8fbba75a6b10c4ed7a48543dce3ee5a1c4a4380822806bc17b4
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/resources/remote-desktop/desktop-files/openmpp.desktop
+++ b/resources/remote-desktop/desktop-files/openmpp.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=OpenM++
-Exec=/opt/openmpp/1.16.0/bin/ompp_ui_linux.sh
+Exec=/opt/openmpp/1.16.1/bin/ompp_ui_linux.sh
 Icon=/resources/openmpp.png
 Terminal=false
 Categories=Development;

--- a/resources/remote-desktop/desktop-files/openmpp.desktop
+++ b/resources/remote-desktop/desktop-files/openmpp.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=OpenM++
-Exec=/opt/openmpp/1.15.6/bin/ompp_ui_linux.sh
+Exec=/opt/openmpp/1.16.0/bin/ompp_ui_linux.sh
 Icon=/resources/openmpp.png
 Terminal=false
 Categories=Development;


### PR DESCRIPTION
# Description

Updated OpenM to version 1.16.0

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [x] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [x] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
