### PR TITLE
updated jupyer-server-proxy package

### DIFF
--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -59,7 +59,7 @@ RUN pip install \
     'markupsafe' \
     'ipympl' \
     'pexpect==4.9.0' \
-    'jupyter-server-proxy' \
+    'jupyter-server-proxy==4.1.2' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \
     'nb_conda_kernels' \

--- a/docker-bits/6_rstudio.Dockerfile
+++ b/docker-bits/6_rstudio.Dockerfile
@@ -28,8 +28,8 @@ RUN mamba install --quiet --yes \
 
 RUN python3 -m pip install \
       'jupyter-rsession-proxy==2.2.0' \
-      'jupyter-shiny-proxy==1.1' && \
       'jupyter-server-proxy==4.1.2' \
+      'jupyter-shiny-proxy==1.1' && \
       fix-permissions $CONDA_DIR && \
       fix-permissions /home/$NB_USER
 

--- a/docker-bits/6_rstudio.Dockerfile
+++ b/docker-bits/6_rstudio.Dockerfile
@@ -29,6 +29,7 @@ RUN mamba install --quiet --yes \
 RUN python3 -m pip install \
       'jupyter-rsession-proxy==2.2.0' \
       'jupyter-shiny-proxy==1.1' && \
+      'jupyter-server-proxy==4.1.2' \
       fix-permissions $CONDA_DIR && \
       fix-permissions /home/$NB_USER
 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -212,7 +212,7 @@ RUN pip install \
     'markupsafe' \
     'ipympl' \
     'pexpect==4.9.0' \
-    'jupyter-server-proxy' \
+    'jupyter-server-proxy==4.1.2' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \
     'nb_conda_kernels' \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -234,7 +234,7 @@ RUN pip install \
     'markupsafe' \
     'ipympl' \
     'pexpect==4.9.0' \
-    'jupyter-server-proxy' \
+    'jupyter-server-proxy==4.1.2' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \
     'nb_conda_kernels' \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -341,7 +341,7 @@ RUN pip install \
     'markupsafe' \
     'ipympl' \
     'pexpect==4.9.0' \
-    'jupyter-server-proxy' \
+    'jupyter-server-proxy==4.1.2' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \
     'nb_conda_kernels' \

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -202,6 +202,7 @@ RUN mamba install --quiet --yes \
 RUN python3 -m pip install \
       'jupyter-rsession-proxy==2.2.0' \
       'jupyter-shiny-proxy==1.1' && \
+      'jupyter-server-proxy==4.1.2' \
       fix-permissions $CONDA_DIR && \
       fix-permissions /home/$NB_USER
 

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -201,8 +201,8 @@ RUN mamba install --quiet --yes \
 
 RUN python3 -m pip install \
       'jupyter-rsession-proxy==2.2.0' \
-      'jupyter-shiny-proxy==1.1' && \
       'jupyter-server-proxy==4.1.2' \
+      'jupyter-shiny-proxy==1.1' && \
       fix-permissions $CONDA_DIR && \
       fix-permissions /home/$NB_USER
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -349,6 +349,7 @@ RUN mamba install --quiet --yes \
 RUN python3 -m pip install \
       'jupyter-rsession-proxy==2.2.0' \
       'jupyter-shiny-proxy==1.1' && \
+      'jupyter-server-proxy==4.1.2' \
       fix-permissions $CONDA_DIR && \
       fix-permissions /home/$NB_USER
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -348,8 +348,8 @@ RUN mamba install --quiet --yes \
 
 RUN python3 -m pip install \
       'jupyter-rsession-proxy==2.2.0' \
-      'jupyter-shiny-proxy==1.1' && \
       'jupyter-server-proxy==4.1.2' \
+      'jupyter-shiny-proxy==1.1' && \
       fix-permissions $CONDA_DIR && \
       fix-permissions /home/$NB_USER
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -213,7 +213,7 @@ RUN pip install \
     'markupsafe' \
     'ipympl' \
     'pexpect==4.9.0' \
-    'jupyter-server-proxy' \
+    'jupyter-server-proxy==4.1.2' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \
     'nb_conda_kernels' \


### PR DESCRIPTION
# Description

Fixes https://github.com/StatCan/aaw-private/issues/178

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [x] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [x] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [x] Does VS Code open?
- [x] Can you install extensions?

## Code review

- [x] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [x] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?

TESTED WITH k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:10d4b1e7
