### PR TITLE
Add font dev packages for r dependencies

### DIFF
--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -18,7 +18,12 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
-  && \
+      # these are required by some r packages, adding these here so they get
+      # installed into all images.
+      'libfreetype6-dev' \
+      'libpng-dev' \
+      'libtiff5-dev' \
+      'libjpeg-dev' && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -75,7 +75,12 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
-  && \
+      # these are required by some r packages, adding these here so they get
+      # installed into all images.
+      'libfreetype6-dev' \
+      'libpng-dev' \
+      'libtiff5-dev' \
+      'libjpeg-dev' && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -97,7 +97,12 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
-  && \
+      # these are required by some r packages, adding these here so they get
+      # installed into all images.
+      'libfreetype6-dev' \
+      'libpng-dev' \
+      'libtiff5-dev' \
+      'libjpeg-dev' && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -204,7 +204,12 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
-  && \
+      # these are required by some r packages, adding these here so they get
+      # installed into all images.
+      'libfreetype6-dev' \
+      'libpng-dev' \
+      'libtiff5-dev' \
+      'libjpeg-dev' && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -150,7 +150,12 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
-  && \
+      # these are required by some r packages, adding these here so they get
+      # installed into all images.
+      'libfreetype6-dev' \
+      'libpng-dev' \
+      'libtiff5-dev' \
+      'libjpeg-dev' && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -75,7 +75,12 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
-  && \
+      # these are required by some r packages, adding these here so they get
+      # installed into all images.
+      'libfreetype6-dev' \
+      'libpng-dev' \
+      'libtiff5-dev' \
+      'libjpeg-dev' && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -76,7 +76,12 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
-  && \
+      # these are required by some r packages, adding these here so they get
+      # installed into all images.
+      'libfreetype6-dev' \
+      'libpng-dev' \
+      'libtiff5-dev' \
+      'libjpeg-dev' && \
     rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
These dev packages are required by some important R packages:

![image](https://github.com/StatCan/aaw-kubeflow-containers/assets/8212170/fa7d1bf3-b4af-4bc8-8403-7a59dcb48b40)

More info can be found here:
- https://jirab.statcan.ca/browse/BTIS-235