### PR TITLE
Add pkg config to conda

### DIFF
--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -51,6 +51,9 @@ RUN pip install \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \
+    # https://stackoverflow.com/questions/68824450/error-configuration-failed-for-package-ragg
+    # need to add mamba install pkg-config so R can find freetype related packages
+    'pkg-config' \
     'jupyterlab' \
     'jupyter_contrib_nbextensions' \ 
     'dash' \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -212,6 +212,9 @@ RUN pip install \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \
+    # https://stackoverflow.com/questions/68824450/error-configuration-failed-for-package-ragg
+    # need to add mamba install pkg-config so R can find freetype related packages
+    'pkg-config' \
     'jupyterlab' \
     'jupyter_contrib_nbextensions' \ 
     'dash' \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -234,6 +234,9 @@ RUN pip install \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \
+    # https://stackoverflow.com/questions/68824450/error-configuration-failed-for-package-ragg
+    # need to add mamba install pkg-config so R can find freetype related packages
+    'pkg-config' \
     'jupyterlab' \
     'jupyter_contrib_nbextensions' \ 
     'dash' \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -341,6 +341,9 @@ RUN pip install \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \
+    # https://stackoverflow.com/questions/68824450/error-configuration-failed-for-package-ragg
+    # need to add mamba install pkg-config so R can find freetype related packages
+    'pkg-config' \
     'jupyterlab' \
     'jupyter_contrib_nbextensions' \ 
     'dash' \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -213,6 +213,9 @@ RUN pip install \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \
+    # https://stackoverflow.com/questions/68824450/error-configuration-failed-for-package-ragg
+    # need to add mamba install pkg-config so R can find freetype related packages
+    'pkg-config' \
     'jupyterlab' \
     'jupyter_contrib_nbextensions' \ 
     'dash' \

--- a/tests/general/test_packages.py
+++ b/tests/general/test_packages.py
@@ -97,7 +97,8 @@ EXCLUDED_PACKAGES = [
     # pytables has been added because it is causing issues, TODO: understand issue and resolve
     # pytables is the package but we import tables
     "tables",
-    "pytables"
+    "pytables",
+    "pkg-config"
 ]
 
 


### PR DESCRIPTION
This was necessary to actually fix https://jirab.statcan.ca/browse/BTIS-235.

R seems to require that we have pkg-config installed by mamba/conda.

- https://stackoverflow.com/questions/68824450/error-configuration-failed-for-package-ragg