### PR TITLE
fix(Test Images): pinned requests package

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -163,7 +163,7 @@ jobs:
         make install-python-dev-venv
     
     - name: Test image
-     run: make test/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }}
+      run: make test/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }}
 
     # Free up space from build process (containerscan action will run out of space if we don't)
     - run: ./.github/scripts/cleanup_runner.sh

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -162,9 +162,8 @@ jobs:
         python -m pip install --upgrade pip
         make install-python-dev-venv
     
-    #AAW: Commented out because it is causing issues
-    #- name: Test image
-    # run: make test/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }}
+    - name: Test image
+     run: make test/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }}
 
     # Free up space from build process (containerscan action will run out of space if we don't)
     - run: ./.github/scripts/cleanup_runner.sh

--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,7 @@ check-test-prereqs: check-python-venv check-port-available
 install-python-dev-venv:
 	python3 -m venv $(PYTHON_VENV)
 	$(PYTHON) -m pip install -Ur requirements-dev.txt
+	$(PYTHON) -m pip list
 
 test/%: REPO?=$(DEFAULT_REPO)
 test/%: TAG?=$(DEFAULT_TAG)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ docker
 # pre-commit
 pytest
 recommonmark
-requests
+requests==2.31.0
 # sphinx>=1.6
 # sphinx-intl
 tabulate

--- a/tests/general/test_packages.py
+++ b/tests/general/test_packages.py
@@ -96,6 +96,7 @@ EXCLUDED_PACKAGES = [
     # import yaml, not import pyyaml
     "pyyaml",
     "graphviz",
+    "tables",
 ]
 
 

--- a/tests/general/test_packages.py
+++ b/tests/general/test_packages.py
@@ -96,7 +96,7 @@ EXCLUDED_PACKAGES = [
     # import yaml, not import pyyaml
     "pyyaml",
     "graphviz",
-    "tables",
+    "pytables",
 ]
 
 


### PR DESCRIPTION
# Description

**What your PR adds/fixes/removes**

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
