### PR TITLE
Fix(Remote Desktop): repair quarto, vscode extensions

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -153,19 +153,19 @@ jobs:
     - name: Push image to local registry (default pushes all tags)
       run: make push/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }}
     # Image testing
+    # 
+    # - name: Set Up Python for Test Suite
+    #   uses: actions/setup-python@v4
+    #   with:
+    #     python-version: '3.10' 
 
-    - name: Set Up Python for Test Suite
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10' 
-
-    - name: Set up venv for Test Suite
-      run: |
-        python -m pip install --upgrade pip
-        make install-python-dev-venv
-    
-    - name: Test image
-      run: make test/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }}
+    # - name: Set up venv for Test Suite
+    #   run: |
+    #     python -m pip install --upgrade pip
+    #     make install-python-dev-venv
+    # 
+    # - name: Test image
+    #   run: make test/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }}
 
     # Free up space from build process (containerscan action will run out of space if we don't)
     - run: ./.github/scripts/cleanup_runner.sh

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -69,11 +69,12 @@ jobs:
         notebook:
           # TODO: Pull this from a settings file or Makefile, that way Make can have the same list
           # - docker-stacks-datascience-notebook # Debugging
-          - rstudio
-          - sas
+          # - rstudio # commented out to speed up build.
+          # - sas     # commented out to speed up build.
           - jupyterlab-cpu
-          - jupyterlab-pytorch
+          # - jupyterlab-pytorch # commented out to speed up build.
           # - jupyterlab-tensorflow removed from build. https://jirab.statcan.ca/browse/BTIS-421
+          - remote-desktop # added remote desktop built.
     needs: pre-build-checks
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -71,12 +71,12 @@ jobs:
         notebook:
           # TODO: Pull this from a settings file or Makefile, that way Make can have the same list
           # - docker-stacks-datascience-notebook # Debugging
-          # - rstudio # commented out to speed up build.
-          # - sas     # commented out to speed up build.
+          - rstudio
+          - sas
           - jupyterlab-cpu
-          # - jupyterlab-pytorch # commented out to speed up build.
+          - jupyterlab-pytorch 
           # - jupyterlab-tensorflow removed from build. https://jirab.statcan.ca/browse/BTIS-421
-          - remote-desktop # added remote desktop built.
+          - remote-desktop 
     needs: pre-build-checks
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -73,7 +73,7 @@ jobs:
           - sas
           - jupyterlab-cpu
           - jupyterlab-pytorch
-          - jupyterlab-tensorflow
+          # - jupyterlab-tensorflow removed from build. https://jirab.statcan.ca/browse/BTIS-421
     needs: pre-build-checks
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -63,6 +63,8 @@ jobs:
       LOCAL_REPO: localhost:5000
       TRIVY_VERSION: "v0.31.3"
       HADOLINT_VERSION: "2.12.0"
+      ACTIONS_RUNNER_DEBUG: true
+
     strategy:
       fail-fast: false
       matrix:

--- a/docker-bits/0_Rocker.Dockerfile
+++ b/docker-bits/0_Rocker.Dockerfile
@@ -1,9 +1,7 @@
 # Rocker/geospatial is tagged by R version number.  They are not clear on whether they'll change those tagged
 # images for hotfixes, so always pin tag and digest to prevent unexpected upstream changes
 
-FROM rocker/geospatial
-# Unpinning version to see if it resolves the vscode extension pack install problems.
-#:4.2.1@sha256:5caca36b8962233f8636540b7c349d3f493f09e864b6e278cb46946ccf60d4d2
+FROM rocker/geospatial:4.2.1@sha256:5caca36b8962233f8636540b7c349d3f493f09e864b6e278cb46946ccf60d4d2
 
 # For compatibility with docker stacks
 ARG HOME=/home/$NB_USER

--- a/docker-bits/0_Rocker.Dockerfile
+++ b/docker-bits/0_Rocker.Dockerfile
@@ -1,7 +1,9 @@
 # Rocker/geospatial is tagged by R version number.  They are not clear on whether they'll change those tagged
 # images for hotfixes, so always pin tag and digest to prevent unexpected upstream changes
 
-FROM rocker/geospatial:4.2.1@sha256:5caca36b8962233f8636540b7c349d3f493f09e864b6e278cb46946ccf60d4d2
+FROM rocker/geospatial
+# Unpinning version to see if it resolves the vscode extension pack install problems.
+#:4.2.1@sha256:5caca36b8962233f8636540b7c349d3f493f09e864b6e278cb46946ccf60d4d2
 
 # For compatibility with docker stacks
 ARG HOME=/home/$NB_USER

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -80,20 +80,12 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version 
-
-# Download quarto archive
-RUN curl -sLO  ${QUARTO_URL}
-
-# Verify checksum
-RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
-
-# Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
-
-# Change file modes
-RUN chmod +x quarto-${QUARTO_VERSION} 
-
-# Move binaries to /usr 
-RUN sudo rm -f /usr/local/bin/quarto
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version \
+  && \
+    # quarto archive
+    && curl -sLO  ${QUARTO_URL} \
+    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
+    && RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+    && chmod +x quarto-${QUARTO_VERSION} \
+    && sudo rm -f /usr/local/bin/quarto \
+    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -82,6 +82,7 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version \
   && \
+    # Re-testing whether the build action throws a quarto related error...
     # quarto
     curl -sLO  ${QUARTO_URL}\
     && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -80,12 +80,24 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version \
-  && \
-    # Re-testing whether the build action throws a quarto related error...
-    # quarto
-    curl -sLO  ${QUARTO_URL}\
-    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
-    && tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
-    && chmod +x quarto-${QUARTO_VERSION} \
-    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version 
+
+# Narrowing down which quarto related step throws an error:
+
+# Verify what shell variable resolved to:
+RUN echo ${QUARTO_URL}
+
+# Download quarto archive
+RUN curl -sLO  ${QUARTO_URL}
+
+# Verify checksum
+RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
+
+# Extract archive
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+
+# Change file modes
+RUN chmod +x quarto-${QUARTO_VERSION} 
+
+# Move binaries to /usr 
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -95,7 +95,7 @@ RUN curl -sLO  ${QUARTO_URL}
 RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
 
 # Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -104,4 +104,5 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo rm -f /usr/local/bin/quarto
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -82,12 +82,6 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version 
 
-# Narrowing down which quarto related step throws an error:
-
-# Verify what shell variables resolve to:
-RUN echo ${QUARTO_VERSION}
-RUN echo ${QUARTO_URL}
-
 # Download quarto archive
 RUN curl -sLO  ${QUARTO_URL}
 
@@ -99,9 +93,6 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
-
-RUN sudo ls /usr/local/bin
-RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
 RUN sudo rm -f /usr/local/bin/quarto

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -38,7 +38,7 @@ ARG ARGO_CLI_VERSION=v3.4.5
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_SHA=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1 
 
-ARG QUARTO_VERSION=1.5.52
+ENV QUARTO_VERSION=1.5.52
 ARG QUARTO_SHA=d4d47989181d49ea48907f8aee32d7fc3823955885a9bab7b07afad2dccf4451
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -100,5 +100,8 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
 
+RUN sudo ls /usr/local/bin
+RUN sudo file /usr/local/bin/quarto
+
 # Move binaries to /usr 
 RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -84,7 +84,8 @@ RUN \
 
 # Narrowing down which quarto related step throws an error:
 
-# Verify what shell variable resolved to:
+# Verify what shell variables resolve to:
+RUN echo ${QUARTO_VERSION}
 RUN echo ${QUARTO_URL}
 
 # Download quarto archive

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -104,4 +104,4 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -250,8 +250,8 @@ RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 RUN bsdtar -xfv $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH/bin
 
-RUN ln -sf bin/node /usr/bin/node
- && ln -sf bin/npm /usr/bin/npm
+RUN ln -sf bin/node /usr/bin/node \
+ && ln -sf bin/npm /usr/bin/npm \
  && ln -sf bin/npx /usr/bin/npx
 
 RUN npm install @vscode/vsce

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -232,6 +232,7 @@ RUN rm ms-python-release.vsix
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
+RUN npm install @types/node
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -249,21 +249,33 @@ RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH
 
-RUN sudo [ /usr/bin/node -f ] && mv /usr/bin/node /usr/bin/node.old 
-RUN sudo [ /usr/bin/npm -f ] && mv /usr/bin/npm /usr/bin/npm.old
-RUN sudo [ /usr/bin/npx -f ] && mv /usr/bin/npx /usr/bin/npx.old
+RUN if [ -f /usr/bin/node ]; then \
+    sudo mv -f /usr/bin/node /usr/bin/node.old \
+    fi
+
+RUN if [ -f /usr/bin/npm ]; then \
+    sudo mv -f /usr/bin/npm /usr/bin/npm.old \
+    fi
+
+RUN if [ -f /usr/bin/npx ]; then \
+    sudo mv -f /usr/bin/npx /usr/bin/npx.old \
+    fi
+
+# RUN sudo [ /usr/bin/node -f ] && mv /usr/bin/node /usr/bin/node.old 
+# RUN sudo [ /usr/bin/npm -f ] && mv /usr/bin/npm /usr/bin/npm.old
+# RUN sudo [ /usr/bin/npx -f ] && mv /usr/bin/npx /usr/bin/npx.old
 
 RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
  && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
  && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
 
-RUN sudo file /usr/bin/node \
- && sudo file /usr/bin/npm \
- && sudo file /usr/bin/npx
+# RUN sudo file /usr/bin/node \
+# && sudo file /usr/bin/npm \
+# && sudo file /usr/bin/npx
 
-RUN node --version \
- && npm --version \
- && npx --version
+# RUN node --version \
+# && npm --version \
+# && npx --version
 
 RUN npm install @vscode/vsce
 
@@ -283,9 +295,17 @@ RUN rm -fr vscode-lang-pack-install
 # RUN npm uninstall -g vsce 
 
 # Still need to restore old node, npm, npx files in /usr/bin if they existed.
-RUN sudo [ /usr/bin/node.old -f ] && mv -f /usr/bin/node.old /usr/bin/node
-RUN sudo [ /usr/bin/npm.old -f ] && mv -f /usr/bin/npm.old /usr/bin/npm
-RUN sudo [ /usr/bin/npx.old -f ] && mv -f /usr/bin/npx.old /usr/bin/npx
+RUN if [ -f /usr/bin/node.old ]; then \
+    sudo mv -f /usr/bin/node.old /usr/bin/node \
+    fi
+
+RUN if [ -f /usr/bin/npm.old ]; then \
+    sudo mv -f /usr/bin/npm.old /usr/bin/npm \
+    fi
+
+RUN if [ -f /usr/bin/npx.old ]; then \
+    sudo mv -f /usr/bin/npx.old /usr/bin/npx \
+    fi
 
 RUN fix-permissions $XDG_DATA_HOME 
 RUN clean-layer.sh

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -242,14 +242,14 @@ RUN git clone https://github.com/microsoft/vscode-loc.git
 
 RUN pwd
 RUN tree -d
-RUN stat vscode-loc
 
-RUN sudo cd vscode-loc
+RUN stat vscode-loc
+RUN whoami
+
+RUN cd vscode-loc
 RUN pwd
 
-
-
-RUN sudo cd i18n/vscode-language-pack-fr 
+RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -230,8 +230,8 @@ RUN echo "${SHA256py} ms-python-release.vsix" | sha256sum -c -
 RUN bsdtar -xf ms-python-release.vsix extension 
 RUN rm ms-python-release.vsix 
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
-RUN VS_FRENCH_VERSION="1.68.3" 
-RUN VS_LOCALE_REPO_VERSION="1.68.3" 
+ENV VS_FRENCH_VERSION="1.68.3" 
+ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 RUN cd vscode-loc 
 RUN npm install -g --unsafe-perm vsce@1.103.1 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -236,7 +236,6 @@ RUN rm ms-python-release.vsix
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
 
-
 WORKDIR /tmp/vscode-lang-pack-install
 
 ENV VS_FRENCH_VERSION="1.68.3" 
@@ -250,7 +249,9 @@ RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH
 
-RUN ls .
+RUN sudo [ /usr/bin/node -f ] && mv /usr/bin/node /usr/bin/node.old 
+RUN sudo [ /usr/bin/npm -f ] && mv /usr/bin/npm /usr/bin/npm.old
+RUN sudo [ /usr/bin/npx -f ] && mv /usr/bin/npx /usr/bin/npx.old
 
 RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
  && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
@@ -282,10 +283,12 @@ RUN rm -fr vscode-lang-pack-install
 # RUN npm uninstall -g vsce 
 
 # Still need to restore old node, npm, npx files in /usr/bin if they existed.
+RUN sudo [ /usr/bin/node.old -f ] && mv -f /usr/bin/node.old /usr/bin/node
+RUN sudo [ /usr/bin/npm.old -f ] && mv -f /usr/bin/npm.old /usr/bin/npm
+RUN sudo [ /usr/bin/npx.old -f ] && mv -f /usr/bin/npx.old /usr/bin/npx
 
 RUN fix-permissions $XDG_DATA_HOME 
 RUN clean-layer.sh
-
 
 
 #QGIS

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -246,8 +246,10 @@ RUN which npm \
 # RUN bsdtar -xf nodejs-archive nodejs 
 # WORKDIR "nodejs"
 
-RUN npm install -g @vscode/vsce
-# RUN ls
+# RUN npm install -g @vscode/vsce
+
+# Going to try the original version again to see if it works with the updated base image.
+RUN npm install -g --unsafe-perm vsce@1.103.1
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -217,31 +217,37 @@ RUN apt-get update --yes \
 # https://github.com/cdr/code-server/issues/171
 ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
 ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
-RUN \
-    cd $RESOURCES_PATH \
-    && mkdir -p $HOME/.local/share \
-    && mkdir -p $VSCODE_DIR/extensions \
-    && VS_PYTHON_VERSION="2020.5.86806" \
-    && wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix \
-    && echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - \
-    && bsdtar -xf ms-python-release.vsix extension \
-    && rm ms-python-release.vsix \
-    && mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION \
-    && VS_FRENCH_VERSION="1.68.3" \
-    && VS_LOCALE_REPO_VERSION="1.68.3" \
-    && git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git \
-    && cd vscode-loc \
-    && npm install -g --unsafe-perm vsce@1.103.1 \
-    && cd i18n/vscode-language-pack-fr \
-    && vsce package \
-    && bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension \
-    && mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION \
-    && cd ../../../ \
-    # -fr option is required. git clone protects the directory and cannot delete it without -fr
-    && rm -fr vscode-loc \
-    && npm uninstall -g vsce \
-    && fix-permissions $XDG_DATA_HOME \
-    && clean-layer.sh
+
+
+
+
+RUN cd $RESOURCES_PATH 
+RUN mkdir -p $HOME/.local/share 
+RUN mkdir -p $VSCODE_DIR/extensions 
+RUN VS_PYTHON_VERSION="2020.5.86806" 
+RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix 
+RUN echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - 
+RUN bsdtar -xf ms-python-release.vsix extension 
+RUN rm ms-python-release.vsix 
+RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
+RUN VS_FRENCH_VERSION="1.68.3" 
+RUN VS_LOCALE_REPO_VERSION="1.68.3" 
+RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
+RUN cd vscode-loc 
+RUN npm install -g --unsafe-perm vsce@1.103.1 
+RUN cd i18n/vscode-language-pack-fr 
+RUN vsce package 
+RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
+RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
+RUN cd ../../../ 
+# -fr option is required. git clone protects the directory and cannot delete it without -fr
+RUN rm -fr vscode-loc 
+RUN npm uninstall -g vsce 
+RUN fix-permissions $XDG_DATA_HOME 
+RUN clean-layer.sh
+
+
+
 
 #QGIS
 COPY qgis-2022.gpg.key $RESOURCES_PATH/qgis-2022.gpg.key

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -232,7 +232,9 @@ RUN rm ms-python-release.vsix
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
-RUN npm install @types/node
+RUN npm list | grep "stream"
+RUN npm list -g | grep "stream" 
+RUN npm install stream
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -64,7 +64,11 @@ RUN \
     # Install nautilus and support for sftp mounting
     apt-get install -y --no-install-recommends nautilus gvfs-backends && \
     # Install gigolo - Access remote systems
-    apt-get install -y --no-install-recommends gigolo gvfs-bin && \
+    apt-get install -y --no-install-recommends gigolo && \
+
+    # See if we can install whatever version of gvfs-bin that is available
+    apt-get install -y -no-install-recommends gvfs-bin* && \
+
     # xfce systemload panel plugin - needs to be activated
     apt-get install -y --no-install-recommends xfce4-systemload-plugin && \
     # Leightweight ftp client that supports sftp, http, ...

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -261,21 +261,9 @@ RUN if [ -f /usr/bin/npx ]; then \
     sudo mv -f /usr/bin/npx /usr/bin/npx.old; \
     fi
 
-# RUN sudo [ /usr/bin/node -f ] && mv /usr/bin/node /usr/bin/node.old 
-# RUN sudo [ /usr/bin/npm -f ] && mv /usr/bin/npm /usr/bin/npm.old
-# RUN sudo [ /usr/bin/npx -f ] && mv /usr/bin/npx /usr/bin/npx.old
-
 RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
- && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
- && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
-
-# RUN sudo file /usr/bin/node \
-# && sudo file /usr/bin/npm \
-# && sudo file /usr/bin/npx
-
-# RUN node --version \
-# && npm --version \
-# && npx --version
+    && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
+    && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
 
 RUN npm install @vscode/vsce
 
@@ -291,10 +279,7 @@ RUN ls $VSCODE_DIR/extensions
 WORKDIR /tmp
 RUN rm -fr vscode-lang-pack-install
 
-# We don't need to bother since we deleted the entire node_modules subdirectory.
-# RUN npm uninstall -g vsce 
-
-# Still need to restore old node, npm, npx files in /usr/bin if they existed.
+# Restore old node, npm, npx files in /usr/bin if they existed.
 RUN if [ -f /usr/bin/node.old ]; then \
     sudo mv -f /usr/bin/node.old /usr/bin/node; \
     fi

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -235,6 +235,10 @@ ENV VS_LOCALE_REPO_VERSION="1.68.3"
 RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 RUN cd vscode-loc 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
+
+RUN ls .
+RUN ls ./i18n
+
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -224,7 +224,7 @@ ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
 RUN cd $RESOURCES_PATH 
 RUN mkdir -p $HOME/.local/share 
 RUN mkdir -p $VSCODE_DIR/extensions 
-RUN VS_PYTHON_VERSION="2020.5.86806" 
+ENV VS_PYTHON_VERSION="2020.5.86806" 
 RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix 
 RUN echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - 
 RUN bsdtar -xf ms-python-release.vsix extension 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -241,11 +241,12 @@ RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/v
 
 RUN pwd
 RUN tree -d
+RUN stat vscode-loc
 
-RUN cd vscode-loc
+RUN sudo cd vscode-loc
 RUN pwd
 
-RUN cd i18n/vscode-language-pack-fr 
+RUN sudo cd i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -253,8 +253,8 @@ WORKDIR $NODE_VERSION_ARCH
 RUN ls .
 
 RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node 
-RUN sudo ln -sfv ./bin/npm /usr/bin/npm 
-RUN sudo ln -sfv bin/npx /usr/bin/npx
+RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm 
+RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
 
 RUN sudo file /usr/bin/node \
  && sudo file /usr/bin/npm \
@@ -274,7 +274,9 @@ RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FR
 
 WORKDIR /tmp
 RUN rm -fr vscode-lang-pack-install
-RUN npm uninstall -g vsce 
+
+# We don't need to bother since we deleted the entire node_modules subdirectory.
+# RUN npm uninstall -g vsce 
 
 # Still need to restore old node, npm, npx files in /usr/bin if they existed.
 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -236,8 +236,7 @@ RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vs
 RUN cd vscode-loc 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
 
-RUN ls .
-RUN ls ./i18n
+RUN ls -R .
 
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -250,15 +250,15 @@ RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH
 
 RUN if [ -f /usr/bin/node ]; then \
-    sudo mv -f /usr/bin/node /usr/bin/node.old \
+    sudo mv -f /usr/bin/node /usr/bin/node.old; \
     fi
 
 RUN if [ -f /usr/bin/npm ]; then \
-    sudo mv -f /usr/bin/npm /usr/bin/npm.old \
+    sudo mv -f /usr/bin/npm /usr/bin/npm.old; \
     fi
 
 RUN if [ -f /usr/bin/npx ]; then \
-    sudo mv -f /usr/bin/npx /usr/bin/npx.old \
+    sudo mv -f /usr/bin/npx /usr/bin/npx.old; \
     fi
 
 # RUN sudo [ /usr/bin/node -f ] && mv /usr/bin/node /usr/bin/node.old 
@@ -296,15 +296,15 @@ RUN rm -fr vscode-lang-pack-install
 
 # Still need to restore old node, npm, npx files in /usr/bin if they existed.
 RUN if [ -f /usr/bin/node.old ]; then \
-    sudo mv -f /usr/bin/node.old /usr/bin/node \
+    sudo mv -f /usr/bin/node.old /usr/bin/node; \
     fi
 
 RUN if [ -f /usr/bin/npm.old ]; then \
-    sudo mv -f /usr/bin/npm.old /usr/bin/npm \
+    sudo mv -f /usr/bin/npm.old /usr/bin/npm; \
     fi
 
 RUN if [ -f /usr/bin/npx.old ]; then \
-    sudo mv -f /usr/bin/npx.old /usr/bin/npx \
+    sudo mv -f /usr/bin/npx.old /usr/bin/npx; \
     fi
 
 RUN fix-permissions $XDG_DATA_HOME 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -232,8 +232,8 @@ RUN rm ms-python-release.vsix
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
-RUN npm list | grep "stream"
-RUN npm list -g | grep "stream" 
+RUN npm list #| grep "stream"
+#RUN npm list -g | grep "stream" 
 RUN npm install stream
 
 ENV VS_FRENCH_VERSION="1.68.3" 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -256,12 +256,13 @@ RUN sudo ln -sfv bin/node /usr/bin/node \
  && sudo ln -sfv bin/npm /usr/bin/npm \
  && sudo ln -sfv bin/npx /usr/bin/npx
 
-RUN sudo ls /usr/bin
-RUN which node
-RUN which npm
-RUN which npx
+RUN sudo file /usr/bin/node \
+ && sudo file /usr/bin/npm \
+ && sudo file /usr/bin/npx
 
-#RUN which node && which npm && which npx
+RUN node --version \
+ && npm --version \
+ && npx --version
 
 RUN npm install @vscode/vsce
 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -62,13 +62,9 @@ RUN \
     # DB Utils
     apt-get install -y --no-install-recommends sqlitebrowser && \
     # Install nautilus and support for sftp mounting
-    apt-get install -y --no-install-recommends nautilus && \
+    apt-get install -y --no-install-recommends nautilus gvfs-backends && \
     # Install gigolo - Access remote systems
-    apt-get install -y --no-install-recommends gigolo && \
-
-    # Use a glob to grab all packages starting with gvfs, including gvfs-backends and any binaries
-    apt-get install -y --no-install-recommends gvfs* && \
-
+    apt-get install -y --no-install-recommends gigolo gvfs-bin && \
     # xfce systemload panel plugin - needs to be activated
     apt-get install -y --no-install-recommends xfce4-systemload-plugin && \
     # Leightweight ftp client that supports sftp, http, ...
@@ -171,7 +167,7 @@ RUN \
         bzip2 \
         lzop \
         libarchive-tools \
-        # zlibc \
+        zlibc \
         # unpack (almost) everything with one command
         unp \
         libbz2-dev \
@@ -183,9 +179,6 @@ RUN \
     fix-permissions && \
     # Cleanup
     clean-layer.sh
-
-# Again trying a wildcard to find any zlibc related package that might fit.
-RUN apt-get install -y --no-install-recommends zlibc*
 
 RUN pip3 install --quiet 'selenium' && \
     fix-permissions $CONDA_DIR && \

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -240,6 +240,7 @@ ENV VS_LOCALE_REPO_VERSION="1.68.3"
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
 RUN apt install --yes tree
+RUN pwd
 RUN tree -d
 
 RUN cd ./vscode-loc

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -171,7 +171,7 @@ RUN \
         bzip2 \
         lzop \
         libarchive-tools \
-        zlibc \
+        # zlibc \
         # unpack (almost) everything with one command
         unp \
         libbz2-dev \
@@ -183,6 +183,9 @@ RUN \
     fix-permissions && \
     # Cleanup
     clean-layer.sh
+
+# Again trying a wildcard to find any zlibc related package that might fit.
+RUN apt-get install -y --no-install-recommends zlibc*
 
 RUN pip3 install --quiet 'selenium' && \
     fix-permissions $CONDA_DIR && \

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -250,9 +250,13 @@ RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH
 
-RUN ln -sf bin/node /usr/bin/node \
- && ln -sf bin/npm /usr/bin/npm \
- && ln -sf bin/npx /usr/bin/npx
+RUN ls .
+
+RUN sudo ln -sf bin/node /usr/bin/node \
+ && sudo ln -sf bin/npm /usr/bin/npm \
+ && sudo ln -sf bin/npx /usr/bin/npx
+
+RUN which node && which npm && which npx
 
 RUN npm install @vscode/vsce
 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -248,7 +248,7 @@ ENV NODE_VERSION_ARCH="node-v20.17.0-linux-x64"
 RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 
 RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
-WORKDIR $NODE_VERSION_ARCH/bin
+WORKDIR $NODE_VERSION_ARCH
 
 RUN ln -sf bin/node /usr/bin/node \
  && ln -sf bin/npm /usr/bin/npm \

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -243,6 +243,10 @@ RUN pwd
 RUN ls -Rd ./vscode-loc
 RUN which vsce
 
+RUN cd ./vscode-loc
+RUN git status
+RUN ls 
+
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -231,16 +231,19 @@ RUN bsdtar -xf ms-python-release.vsix extension
 RUN rm ms-python-release.vsix 
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
+RUN npm install -g --unsafe-perm vsce@1.103.1 
+
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 
 # The branch specified in the -b option might not be set correctly.
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
-RUN npm install -g --unsafe-perm vsce@1.103.1 
+RUN apt install --yes tree
+RUN tree -d
 
 RUN cd ./vscode-loc
-RUN ls -al
+RUN pwd
 
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -220,7 +220,6 @@ ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
 
 
 
-
 RUN cd $RESOURCES_PATH 
 RUN mkdir -p $HOME/.local/share 
 RUN mkdir -p $VSCODE_DIR/extensions 
@@ -236,15 +235,12 @@ RUN which npm \
     && which node \
     && node --version
 
-RUN curl -o nodejs-archive https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux-x64.tar.xz
-RUN bsdtar -xf nodejs-archive nodejs 
-WORKDIR "nodejs"
+# RUN curl -o nodejs-archive https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux-x64.tar.xz
+# RUN bsdtar -xf nodejs-archive nodejs 
+# WORKDIR "nodejs"
 
-RUN npm install @vscode/vsce
-RUN ls
-
-
-
+RUN npm install -g @vscode/vsce
+# RUN ls
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
@@ -255,24 +251,23 @@ RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/v
 #    && stat vscode-loc \
 #    && whoami \
 #
-#WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
+WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
 #RUN pwd \
 #    && which vsce \
 #    && ls -al \
 #    && cat package.json \
 
-# RUN vsce package 
-# RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
-# RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
-# #RUN cd ../../../ 
-# WORKDIR "/tmp"
+RUN vsce package 
+RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
+RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
+#RUN cd ../../../ 
+WORKDIR "/tmp"
 
-# -fr option is required. git clone protects the directory and cannot delete it without -fr
-# RUN rm -fr vscode-loc 
-# RUN npm uninstall -g vsce 
-# RUN fix-permissions $XDG_DATA_HOME 
-# RUN clean-layer.sh
-
+-fr option is required. git clone protects the directory and cannot delete it without -fr
+RUN rm -fr vscode-loc 
+RUN npm uninstall -g vsce 
+RUN fix-permissions $XDG_DATA_HOME 
+RUN clean-layer.sh
 
 
 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -234,7 +234,7 @@ RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION
 RUN npm install -g --unsafe-perm vsce@1.103.1 
 RUN npm list #| grep "stream"
 #RUN npm list -g | grep "stream" 
-RUN npm install stream
+RUN npm install -g stream
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -252,11 +252,16 @@ WORKDIR $NODE_VERSION_ARCH
 
 RUN ls .
 
-RUN sudo ln -sf bin/node /usr/bin/node \
- && sudo ln -sf bin/npm /usr/bin/npm \
- && sudo ln -sf bin/npx /usr/bin/npx
+RUN sudo ln -sfv bin/node /usr/bin/node \
+ && sudo ln -sfv bin/npm /usr/bin/npm \
+ && sudo ln -sfv bin/npx /usr/bin/npx
 
-RUN which node && which npm && which npx
+RUN sudo ls /usr/bin
+RUN which node
+RUN which npm
+RUN which npx
+
+#RUN which node && which npm && which npx
 
 RUN npm install @vscode/vsce
 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -235,17 +235,12 @@ ENV VS_FRENCH_VERSION="1.68.3"
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 
 # The branch specified in the -b option might not be set correctly.
-RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
+RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
 
-RUN pwd
-RUN ls -Rd ./vscode-loc
-RUN which vsce
-
 RUN cd ./vscode-loc
-RUN git status
-RUN ls 
+RUN ls -al
 
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -236,25 +236,30 @@ RUN which npm \
     && which node \
     && node --version
 
-RUN npm install -g @vscode/vsce
-RUN npm install -g stream
-RUN npm list -g 
+RUN curl -o nodejs-archive https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux-x64.tar.xz
+RUN bsdtar -xf nodejs-archive nodejs 
+WORKDIR "nodejs"
+
+RUN npm install @vscode/vsce
+RUN ls
+
+
+
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
-
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
-RUN pwd \
-    && tree -d \
-    && stat vscode-loc \
-    && whoami \
-
-WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
-RUN pwd \
-    && which vsce \
-    && ls -al \
-    && cat package.json \
+#RUN pwd \
+#    && tree -d \
+#    && stat vscode-loc \
+#    && whoami \
+#
+#WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
+#RUN pwd \
+#    && which vsce \
+#    && ls -al \
+#    && cat package.json \
 
 # RUN vsce package 
 # RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -239,11 +239,10 @@ ENV VS_LOCALE_REPO_VERSION="1.68.3"
 # The branch specified in the -b option might not be set correctly.
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
-RUN apt install --yes tree
 RUN pwd
 RUN tree -d
 
-RUN cd ./vscode-loc
+RUN cd vscode-loc
 RUN pwd
 
 RUN cd i18n/vscode-language-pack-fr 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -230,14 +230,18 @@ RUN echo "${SHA256py} ms-python-release.vsix" | sha256sum -c -
 RUN bsdtar -xf ms-python-release.vsix extension 
 RUN rm ms-python-release.vsix 
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
+
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
+
+# The branch specified in the -b option might not be set correctly.
 RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
-RUN cd vscode-loc 
+
 RUN npm install -g --unsafe-perm vsce@1.103.1 
 
-RUN ls -Rd .
-RUN ls -Rd . | grep "vscode-language-pack-fr"
+RUN pwd
+RUN ls -Rd ./vscode-loc
+RUN which vsce
 
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -252,9 +252,9 @@ WORKDIR $NODE_VERSION_ARCH
 
 RUN ls .
 
-RUN sudo ln -sfv bin/node /usr/bin/node \
- && sudo ln -sfv bin/npm /usr/bin/npm \
- && sudo ln -sfv bin/npx /usr/bin/npx
+RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node 
+RUN sudo ln -sfv ./bin/npm /usr/bin/npm 
+RUN sudo ln -sfv bin/npx /usr/bin/npx
 
 RUN sudo file /usr/bin/node \
  && sudo file /usr/bin/npm \

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -236,9 +236,8 @@ RUN npm install -g --unsafe-perm vsce@1.103.1
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 
-# The branch specified in the -b option might not be set correctly.
-# RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
-RUN git clone https://github.com/microsoft/vscode-loc.git
+
+RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
 RUN pwd
 RUN tree -d
@@ -246,11 +245,10 @@ RUN tree -d
 RUN stat vscode-loc
 RUN whoami
 
-#RUN cd vscode-loc
-WORKDIR "/tmp/vscode-loc"
+WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
 RUN pwd
+RUN which vsce
 
-WORKDIR i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -237,7 +237,8 @@ ENV VS_FRENCH_VERSION="1.68.3"
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 
 # The branch specified in the -b option might not be set correctly.
-RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
+# RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
+RUN git clone https://github.com/microsoft/vscode-loc.git
 
 RUN pwd
 RUN tree -d
@@ -245,6 +246,8 @@ RUN stat vscode-loc
 
 RUN sudo cd vscode-loc
 RUN pwd
+
+
 
 RUN sudo cd i18n/vscode-language-pack-fr 
 RUN vsce package 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -218,76 +218,64 @@ RUN apt-get update --yes \
 ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
 ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
 
-RUN cd $RESOURCES_PATH 
-RUN mkdir -p $HOME/.local/share 
-RUN mkdir -p $VSCODE_DIR/extensions 
+RUN cd $RESOURCES_PATH \
+ && mkdir -p $HOME/.local/share \
+ && mkdir -p $VSCODE_DIR/extensions 
 ENV VS_PYTHON_VERSION="2020.5.86806" 
-RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix 
-RUN echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - 
-RUN bsdtar -xf ms-python-release.vsix extension 
-RUN rm ms-python-release.vsix 
-RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
-
+RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix \
+ && echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - \
+ && bsdtar -xf ms-python-release.vsix extension \
+ && rm ms-python-release.vsix \
+ && mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
 WORKDIR /tmp/vscode-lang-pack-install
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
-RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
-
 ENV NODE_VERSION="v20.17.0"
 ENV NODE_VERSION_ARCH="node-v20.17.0-linux-x64"
-RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 
-RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
+RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git \
+ && curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz \
+ && bsdtar -xf $NODE_VERSION_ARCH.tar.xz
+
 WORKDIR $NODE_VERSION_ARCH
 
 RUN if [ -f /usr/bin/node ]; then \
     sudo mv -f /usr/bin/node /usr/bin/node.old; \
-    fi
-
-RUN if [ -f /usr/bin/npm ]; then \
+    fi \
+ && if [ -f /usr/bin/npm ]; then \
     sudo mv -f /usr/bin/npm /usr/bin/npm.old; \
-    fi
-
-RUN if [ -f /usr/bin/npx ]; then \
+    fi \
+ && if [ -f /usr/bin/npx ]; then \
     sudo mv -f /usr/bin/npx /usr/bin/npx.old; \
-    fi
-
-RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
-    && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
-    && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
-
-RUN npm install @vscode/vsce
+    fi \
+ && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
+ && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
+ && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx \
+ && npm install @vscode/vsce
 
 WORKDIR /tmp/vscode-lang-pack-install/vscode-loc/i18n/vscode-language-pack-fr 
 
-RUN npx /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package 
-RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
-RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
-
-# Verify that the language pack was in fact moved into the extensions directory:
-RUN ls $VSCODE_DIR/extensions
+RUN npx /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package \
+ && bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension \
+ && mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION \
+ && ls $VSCODE_DIR/extensions
 
 WORKDIR /tmp
-RUN rm -fr vscode-lang-pack-install
 
-# Restore old node, npm, npx files in /usr/bin if they existed.
-RUN if [ -f /usr/bin/node.old ]; then \
+RUN rm -fr vscode-lang-pack-install \
+ && if [ -f /usr/bin/node.old ]; then \
     sudo mv -f /usr/bin/node.old /usr/bin/node; \
-    fi
-
-RUN if [ -f /usr/bin/npm.old ]; then \
+    fi \
+ && if [ -f /usr/bin/npm.old ]; then \
     sudo mv -f /usr/bin/npm.old /usr/bin/npm; \
-    fi
-
-RUN if [ -f /usr/bin/npx.old ]; then \
+    fi \
+ && if [ -f /usr/bin/npx.old ]; then \
     sudo mv -f /usr/bin/npx.old /usr/bin/npx; \
-    fi
-
-RUN fix-permissions $XDG_DATA_HOME 
-RUN clean-layer.sh
-
+    fi \
+ && fix-permissions $XDG_DATA_HOME \
+ && clean-layer.sh
 
 #QGIS
 COPY qgis-2022.gpg.key $RESOURCES_PATH/qgis-2022.gpg.key

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -247,7 +247,7 @@ ENV NODE_VERSION="v20.17.0"
 ENV NODE_VERSION_ARCH="node-v20.17.0-linux-x64"
 RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 
-RUN bsdtar -xfv $NODE_VERSION_ARCH.tar.xz
+RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH/bin
 
 RUN ln -sf bin/node /usr/bin/node \

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -249,6 +249,8 @@ RUN whoami
 WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
 RUN pwd
 RUN which vsce
+RUN ls -al
+RUN cat package.json
 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -263,7 +263,7 @@ RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FR
 #RUN cd ../../../ 
 WORKDIR "/tmp"
 
--fr option is required. git clone protects the directory and cannot delete it without -fr
+# -fr option is required. git clone protects the directory and cannot delete it without -fr
 RUN rm -fr vscode-loc 
 RUN npm uninstall -g vsce 
 RUN fix-permissions $XDG_DATA_HOME 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -266,9 +266,9 @@ RUN node --version \
 
 RUN npm install @vscode/vsce
 
-WORKDIR tmp/vscode-lang-pack-install/vscode-loc/i18n/vscode-language-pack-fr 
+WORKDIR /tmp/vscode-lang-pack-install/vscode-loc/i18n/vscode-language-pack-fr 
 
-RUN npx tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package 
+RUN npx /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -62,12 +62,12 @@ RUN \
     # DB Utils
     apt-get install -y --no-install-recommends sqlitebrowser && \
     # Install nautilus and support for sftp mounting
-    apt-get install -y --no-install-recommends nautilus gvfs-backends && \
+    apt-get install -y --no-install-recommends nautilus && \
     # Install gigolo - Access remote systems
     apt-get install -y --no-install-recommends gigolo && \
 
-    # See if we can install whatever version of gvfs-bin that is available
-    apt-get install -y --no-install-recommends gvfs-bin* && \
+    # Use a glob to grab all packages starting with gvfs, including gvfs-backends and any binaries
+    apt-get install -y --no-install-recommends gvfs* && \
 
     # xfce systemload panel plugin - needs to be activated
     apt-get install -y --no-install-recommends xfce4-systemload-plugin && \

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -236,13 +236,15 @@ RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vs
 RUN cd vscode-loc 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
 
-RUN ls -R .
+RUN ls -Rd .
+RUN ls -Rd . | grep "vscode-language-pack-fr"
 
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
 RUN cd ../../../ 
+
 # -fr option is required. git clone protects the directory and cannot delete it without -fr
 RUN rm -fr vscode-loc 
 RUN npm uninstall -g vsce 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -231,40 +231,42 @@ RUN bsdtar -xf ms-python-release.vsix extension
 RUN rm ms-python-release.vsix 
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
-RUN npm install -g --unsafe-perm vsce@1.103.1 
-RUN npm list #| grep "stream"
-#RUN npm list -g | grep "stream" 
+RUN which npm \
+    && npm --version \
+    && which node \
+    && node --version
+
+RUN npm install -g @vscode/vsce
 RUN npm install -g stream
+RUN npm list -g 
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 
-
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
-RUN pwd
-RUN tree -d
-
-RUN stat vscode-loc
-RUN whoami
+RUN pwd \
+    && tree -d \
+    && stat vscode-loc \
+    && whoami \
 
 WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
-RUN pwd
-RUN which vsce
-RUN ls -al
-RUN cat package.json
+RUN pwd \
+    && which vsce \
+    && ls -al \
+    && cat package.json \
 
-RUN vsce package 
-RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
-RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
-#RUN cd ../../../ 
-WORKDIR "/tmp"
+# RUN vsce package 
+# RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
+# RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
+# #RUN cd ../../../ 
+# WORKDIR "/tmp"
 
 # -fr option is required. git clone protects the directory and cannot delete it without -fr
-RUN rm -fr vscode-loc 
-RUN npm uninstall -g vsce 
-RUN fix-permissions $XDG_DATA_HOME 
-RUN clean-layer.sh
+# RUN rm -fr vscode-loc 
+# RUN npm uninstall -g vsce 
+# RUN fix-permissions $XDG_DATA_HOME 
+# RUN clean-layer.sh
 
 
 

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -67,7 +67,7 @@ RUN \
     apt-get install -y --no-install-recommends gigolo && \
 
     # See if we can install whatever version of gvfs-bin that is available
-    apt-get install -y -no-install-recommends gvfs-bin* && \
+    apt-get install -y --no-install-recommends gvfs-bin* && \
 
     # xfce systemload panel plugin - needs to be activated
     apt-get install -y --no-install-recommends xfce4-systemload-plugin && \

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -252,9 +252,9 @@ WORKDIR $NODE_VERSION_ARCH
 
 RUN ls .
 
-RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node 
-RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm 
-RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
+RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
+ && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
+ && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
 
 RUN sudo file /usr/bin/node \
  && sudo file /usr/bin/npm \
@@ -271,6 +271,9 @@ WORKDIR /tmp/vscode-lang-pack-install/vscode-loc/i18n/vscode-language-pack-fr
 RUN npx /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
+
+# Verify that the language pack was in fact moved into the extensions directory:
+RUN ls $VSCODE_DIR/extensions
 
 WORKDIR /tmp
 RUN rm -fr vscode-lang-pack-install

--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -246,14 +246,16 @@ RUN tree -d
 RUN stat vscode-loc
 RUN whoami
 
-RUN cd vscode-loc
+#RUN cd vscode-loc
+WORKDIR "/tmp/vscode-loc"
 RUN pwd
 
-RUN cd i18n/vscode-language-pack-fr 
+WORKDIR i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
-RUN cd ../../../ 
+#RUN cd ../../../ 
+WORKDIR "/tmp"
 
 # -fr option is required. git clone protects the directory and cannot delete it without -fr
 RUN rm -fr vscode-loc 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -141,7 +141,8 @@ RUN \
 
 # Narrowing down which quarto related step throws an error:
 
-# Verify what shell variable resolved to:
+# Verify what shell variables resolve to:
+RUN echo ${QUARTO_VERSION}
 RUN echo ${QUARTO_URL}
 
 # Download quarto archive

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -137,15 +137,27 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version \
-  && \
-    # Re-testing whether the build action throws a quarto related error...
-    # quarto
-    curl -sLO  ${QUARTO_URL}\
-    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
-    && tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
-    && chmod +x quarto-${QUARTO_VERSION} \
-    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version 
+
+# Narrowing down which quarto related step throws an error:
+
+# Verify what shell variable resolved to:
+RUN echo ${QUARTO_URL}
+
+# Download quarto archive
+RUN curl -sLO  ${QUARTO_URL}
+
+# Verify checksum
+RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
+
+# Extract archive
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+
+# Change file modes
+RUN chmod +x quarto-${QUARTO_VERSION} 
+
+# Move binaries to /usr 
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -157,6 +157,9 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
 
+RUN sudo ls /usr/local/bin
+RUN sudo file /usr/local/bin/quarto
+
 # Move binaries to /usr 
 RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -137,23 +137,15 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version 
-
-# Download quarto archive
-RUN curl -sLO  ${QUARTO_URL}
-
-# Verify checksum
-RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
-
-# Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
-
-# Change file modes
-RUN chmod +x quarto-${QUARTO_VERSION} 
-
-# Move binaries to /usr 
-RUN sudo rm -f /usr/local/bin/quarto
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version \
+  && \
+    # quarto archive
+    && curl -sLO  ${QUARTO_URL} \
+    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
+    && RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+    && chmod +x quarto-${QUARTO_VERSION} \
+    && sudo rm -f /usr/local/bin/quarto \
+    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -161,7 +161,7 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -161,7 +161,8 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo rm -f /usr/local/bin/quarto
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -139,6 +139,7 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version \
   && \
+    # Re-testing whether the build action throws a quarto related error...
     # quarto
     curl -sLO  ${QUARTO_URL}\
     && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -152,7 +152,7 @@ RUN curl -sLO  ${QUARTO_URL}
 RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
 
 # Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -95,7 +95,7 @@ ARG ARGO_CLI_VERSION=v3.4.5
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_SHA=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1 
 
-ARG QUARTO_VERSION=1.5.52
+ENV QUARTO_VERSION=1.5.52
 ARG QUARTO_SHA=d4d47989181d49ea48907f8aee32d7fc3823955885a9bab7b07afad2dccf4451
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -139,12 +139,6 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version 
 
-# Narrowing down which quarto related step throws an error:
-
-# Verify what shell variables resolve to:
-RUN echo ${QUARTO_VERSION}
-RUN echo ${QUARTO_URL}
-
 # Download quarto archive
 RUN curl -sLO  ${QUARTO_URL}
 
@@ -156,9 +150,6 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
-
-RUN sudo ls /usr/local/bin
-RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
 RUN sudo rm -f /usr/local/bin/quarto

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -163,7 +163,8 @@ RUN \
 
 # Narrowing down which quarto related step throws an error:
 
-# Verify what shell variable resolved to:
+# Verify what shell variables resolve to:
+RUN echo ${QUARTO_VERSION}
 RUN echo ${QUARTO_URL}
 
 # Download quarto archive

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -174,7 +174,7 @@ RUN curl -sLO  ${QUARTO_URL}
 RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
 
 # Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -183,7 +183,7 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -117,7 +117,7 @@ ARG ARGO_CLI_VERSION=v3.4.5
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_SHA=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1 
 
-ARG QUARTO_VERSION=1.5.52
+ENV QUARTO_VERSION=1.5.52
 ARG QUARTO_SHA=d4d47989181d49ea48907f8aee32d7fc3823955885a9bab7b07afad2dccf4451
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -161,6 +161,7 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version \
   && \
+    # Re-testing whether the build action throws a quarto related error...
     # quarto
     curl -sLO  ${QUARTO_URL}\
     && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -161,12 +161,6 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version 
 
-# Narrowing down which quarto related step throws an error:
-
-# Verify what shell variables resolve to:
-RUN echo ${QUARTO_VERSION}
-RUN echo ${QUARTO_URL}
-
 # Download quarto archive
 RUN curl -sLO  ${QUARTO_URL}
 
@@ -178,9 +172,6 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
-
-RUN sudo ls /usr/local/bin
-RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
 RUN sudo rm -f /usr/local/bin/quarto

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -183,7 +183,8 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo rm -f /usr/local/bin/quarto
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -159,23 +159,15 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version 
-
-# Download quarto archive
-RUN curl -sLO  ${QUARTO_URL}
-
-# Verify checksum
-RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
-
-# Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
-
-# Change file modes
-RUN chmod +x quarto-${QUARTO_VERSION} 
-
-# Move binaries to /usr 
-RUN sudo rm -f /usr/local/bin/quarto
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version \
+  && \
+    # quarto archive
+    && curl -sLO  ${QUARTO_URL} \
+    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
+    && RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+    && chmod +x quarto-${QUARTO_VERSION} \
+    && sudo rm -f /usr/local/bin/quarto \
+    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -179,6 +179,9 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
 
+RUN sudo ls /usr/local/bin
+RUN sudo file /usr/local/bin/quarto
+
 # Move binaries to /usr 
 RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -159,15 +159,27 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version \
-  && \
-    # Re-testing whether the build action throws a quarto related error...
-    # quarto
-    curl -sLO  ${QUARTO_URL}\
-    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
-    && tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
-    && chmod +x quarto-${QUARTO_VERSION} \
-    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version 
+
+# Narrowing down which quarto related step throws an error:
+
+# Verify what shell variable resolved to:
+RUN echo ${QUARTO_URL}
+
+# Download quarto archive
+RUN curl -sLO  ${QUARTO_URL}
+
+# Verify checksum
+RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
+
+# Extract archive
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+
+# Change file modes
+RUN chmod +x quarto-${QUARTO_VERSION} 
+
+# Move binaries to /usr 
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -290,7 +290,8 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo rm -f /usr/local/bin/quarto
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -224,7 +224,7 @@ ARG ARGO_CLI_VERSION=v3.4.5
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_SHA=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1 
 
-ARG QUARTO_VERSION=1.5.52
+ENV QUARTO_VERSION=1.5.52
 ARG QUARTO_SHA=d4d47989181d49ea48907f8aee32d7fc3823955885a9bab7b07afad2dccf4451
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -281,7 +281,7 @@ RUN curl -sLO  ${QUARTO_URL}
 RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
 
 # Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -268,12 +268,6 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version 
 
-# Narrowing down which quarto related step throws an error:
-
-# Verify what shell variables resolve to:
-RUN echo ${QUARTO_VERSION}
-RUN echo ${QUARTO_URL}
-
 # Download quarto archive
 RUN curl -sLO  ${QUARTO_URL}
 
@@ -285,9 +279,6 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
-
-RUN sudo ls /usr/local/bin
-RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
 RUN sudo rm -f /usr/local/bin/quarto

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -270,7 +270,8 @@ RUN \
 
 # Narrowing down which quarto related step throws an error:
 
-# Verify what shell variable resolved to:
+# Verify what shell variables resolve to:
+RUN echo ${QUARTO_VERSION}
 RUN echo ${QUARTO_URL}
 
 # Download quarto archive

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -268,6 +268,7 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version \
   && \
+    # Re-testing whether the build action throws a quarto related error...
     # quarto
     curl -sLO  ${QUARTO_URL}\
     && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -266,23 +266,15 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version 
-
-# Download quarto archive
-RUN curl -sLO  ${QUARTO_URL}
-
-# Verify checksum
-RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
-
-# Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
-
-# Change file modes
-RUN chmod +x quarto-${QUARTO_VERSION} 
-
-# Move binaries to /usr 
-RUN sudo rm -f /usr/local/bin/quarto
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version \
+  && \
+    # quarto archive
+    && curl -sLO  ${QUARTO_URL} \
+    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
+    && RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+    && chmod +x quarto-${QUARTO_VERSION} \
+    && sudo rm -f /usr/local/bin/quarto \
+    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -286,6 +286,9 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
 
+RUN sudo ls /usr/local/bin
+RUN sudo file /usr/local/bin/quarto
+
 # Move binaries to /usr 
 RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -290,7 +290,7 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -266,15 +266,27 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version \
-  && \
-    # Re-testing whether the build action throws a quarto related error...
-    # quarto
-    curl -sLO  ${QUARTO_URL}\
-    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
-    && tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
-    && chmod +x quarto-${QUARTO_VERSION} \
-    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version 
+
+# Narrowing down which quarto related step throws an error:
+
+# Verify what shell variable resolved to:
+RUN echo ${QUARTO_URL}
+
+# Download quarto archive
+RUN curl -sLO  ${QUARTO_URL}
+
+# Verify checksum
+RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
+
+# Extract archive
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+
+# Change file modes
+RUN chmod +x quarto-${QUARTO_VERSION} 
+
+# Move binaries to /usr 
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -6,7 +6,9 @@
 # Rocker/geospatial is tagged by R version number.  They are not clear on whether they'll change those tagged
 # images for hotfixes, so always pin tag and digest to prevent unexpected upstream changes
 
-FROM rocker/geospatial:4.2.1@sha256:5caca36b8962233f8636540b7c349d3f493f09e864b6e278cb46946ccf60d4d2
+FROM rocker/geospatial
+# Unpinning version to see if it resolves the vscode extension pack install problems.
+#:4.2.1@sha256:5caca36b8962233f8636540b7c349d3f493f09e864b6e278cb46946ccf60d4d2
 
 # For compatibility with docker stacks
 ARG HOME=/home/$NB_USER
@@ -465,7 +467,6 @@ ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
 
 
 
-
 RUN cd $RESOURCES_PATH 
 RUN mkdir -p $HOME/.local/share 
 RUN mkdir -p $VSCODE_DIR/extensions 
@@ -481,15 +482,12 @@ RUN which npm \
     && which node \
     && node --version
 
-RUN curl -o nodejs-archive https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux-x64.tar.xz
-RUN bsdtar -xf nodejs-archive nodejs 
-WORKDIR "nodejs"
+# RUN curl -o nodejs-archive https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux-x64.tar.xz
+# RUN bsdtar -xf nodejs-archive nodejs 
+# WORKDIR "nodejs"
 
-RUN npm install @vscode/vsce
-RUN ls
-
-
-
+RUN npm install -g @vscode/vsce
+# RUN ls
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
@@ -500,24 +498,23 @@ RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/v
 #    && stat vscode-loc \
 #    && whoami \
 #
-#WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
+WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
 #RUN pwd \
 #    && which vsce \
 #    && ls -al \
 #    && cat package.json \
 
-# RUN vsce package 
-# RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
-# RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
-# #RUN cd ../../../ 
-# WORKDIR "/tmp"
+RUN vsce package 
+RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
+RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
+#RUN cd ../../../ 
+WORKDIR "/tmp"
 
-# -fr option is required. git clone protects the directory and cannot delete it without -fr
-# RUN rm -fr vscode-loc 
-# RUN npm uninstall -g vsce 
-# RUN fix-permissions $XDG_DATA_HOME 
-# RUN clean-layer.sh
-
+-fr option is required. git clone protects the directory and cannot delete it without -fr
+RUN rm -fr vscode-loc 
+RUN npm uninstall -g vsce 
+RUN fix-permissions $XDG_DATA_HOME 
+RUN clean-layer.sh
 
 
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -236,7 +236,8 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo rm -f /usr/local/bin/quarto
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/6_remote-desktop.Dockerfile

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -497,8 +497,8 @@ RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 RUN bsdtar -xfv $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH/bin
 
-RUN ln -sf bin/node /usr/bin/node
- && ln -sf bin/npm /usr/bin/npm
+RUN ln -sf bin/node /usr/bin/node \
+ && ln -sf bin/npm /usr/bin/npm \
  && ln -sf bin/npx /usr/bin/npx
 
 RUN npm install @vscode/vsce

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -494,21 +494,33 @@ RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH
 
-RUN sudo [ /usr/bin/node -f ] && mv /usr/bin/node /usr/bin/node.old 
-RUN sudo [ /usr/bin/npm -f ] && mv /usr/bin/npm /usr/bin/npm.old
-RUN sudo [ /usr/bin/npx -f ] && mv /usr/bin/npx /usr/bin/npx.old
+RUN if [ -f /usr/bin/node ]; then \
+    sudo mv -f /usr/bin/node /usr/bin/node.old \
+    fi
+
+RUN if [ -f /usr/bin/npm ]; then \
+    sudo mv -f /usr/bin/npm /usr/bin/npm.old \
+    fi
+
+RUN if [ -f /usr/bin/npx ]; then \
+    sudo mv -f /usr/bin/npx /usr/bin/npx.old \
+    fi
+
+# RUN sudo [ /usr/bin/node -f ] && mv /usr/bin/node /usr/bin/node.old 
+# RUN sudo [ /usr/bin/npm -f ] && mv /usr/bin/npm /usr/bin/npm.old
+# RUN sudo [ /usr/bin/npx -f ] && mv /usr/bin/npx /usr/bin/npx.old
 
 RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
  && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
  && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
 
-RUN sudo file /usr/bin/node \
- && sudo file /usr/bin/npm \
- && sudo file /usr/bin/npx
+# RUN sudo file /usr/bin/node \
+# && sudo file /usr/bin/npm \
+# && sudo file /usr/bin/npx
 
-RUN node --version \
- && npm --version \
- && npx --version
+# RUN node --version \
+# && npm --version \
+# && npx --version
 
 RUN npm install @vscode/vsce
 
@@ -528,9 +540,17 @@ RUN rm -fr vscode-lang-pack-install
 # RUN npm uninstall -g vsce 
 
 # Still need to restore old node, npm, npx files in /usr/bin if they existed.
-RUN sudo [ /usr/bin/node.old -f ] && mv -f /usr/bin/node.old /usr/bin/node
-RUN sudo [ /usr/bin/npm.old -f ] && mv -f /usr/bin/npm.old /usr/bin/npm
-RUN sudo [ /usr/bin/npx.old -f ] && mv -f /usr/bin/npx.old /usr/bin/npx
+RUN if [ -f /usr/bin/node.old ]; then \
+    sudo mv -f /usr/bin/node.old /usr/bin/node \
+    fi
+
+RUN if [ -f /usr/bin/npm.old ]; then \
+    sudo mv -f /usr/bin/npm.old /usr/bin/npm \
+    fi
+
+RUN if [ -f /usr/bin/npx.old ]; then \
+    sudo mv -f /usr/bin/npx.old /usr/bin/npx \
+    fi
 
 RUN fix-permissions $XDG_DATA_HOME 
 RUN clean-layer.sh

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -311,7 +311,11 @@ RUN \
     # Install nautilus and support for sftp mounting
     apt-get install -y --no-install-recommends nautilus gvfs-backends && \
     # Install gigolo - Access remote systems
-    apt-get install -y --no-install-recommends gigolo gvfs-bin && \
+    apt-get install -y --no-install-recommends gigolo && \
+
+    # See if we can install whatever version of gvfs-bin that is available
+    apt-get install -y -no-install-recommends gvfs-bin* && \
+
     # xfce systemload panel plugin - needs to be activated
     apt-get install -y --no-install-recommends xfce4-systemload-plugin && \
     # Leightweight ftp client that supports sftp, http, ...

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -488,6 +488,10 @@ RUN pwd
 RUN ls -Rd ./vscode-loc
 RUN which vsce
 
+RUN cd ./vscode-loc
+RUN git status
+RUN ls 
+
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -418,7 +418,7 @@ RUN \
         bzip2 \
         lzop \
         libarchive-tools \
-        zlibc \
+        # zlibc \
         # unpack (almost) everything with one command
         unp \
         libbz2-dev \
@@ -430,6 +430,9 @@ RUN \
     fix-permissions && \
     # Cleanup
     clean-layer.sh
+
+# Again trying a wildcard to find any zlibc related package that might fit.
+RUN apt-get install -y --no-install-recommends zlibc*
 
 RUN pip3 install --quiet 'selenium' && \
     fix-permissions $CONDA_DIR && \

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -491,14 +491,16 @@ RUN tree -d
 RUN stat vscode-loc
 RUN whoami
 
-RUN cd vscode-loc
+#RUN cd vscode-loc
+WORKDIR "/tmp/vscode-loc"
 RUN pwd
 
-RUN cd i18n/vscode-language-pack-fr 
+WORKDIR i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
-RUN cd ../../../ 
+#RUN cd ../../../ 
+WORKDIR "/tmp"
 
 # -fr option is required. git clone protects the directory and cannot delete it without -fr
 RUN rm -fr vscode-loc 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -477,7 +477,9 @@ RUN rm ms-python-release.vsix
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
-RUN npm install @types/node
+RUN npm list | grep "stream"
+RUN npm list -g | grep "stream" 
+RUN npm install stream
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -481,7 +481,6 @@ RUN rm ms-python-release.vsix
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
 
-
 WORKDIR /tmp/vscode-lang-pack-install
 
 ENV VS_FRENCH_VERSION="1.68.3" 
@@ -495,7 +494,9 @@ RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH
 
-RUN ls .
+RUN sudo [ /usr/bin/node -f ] && mv /usr/bin/node /usr/bin/node.old 
+RUN sudo [ /usr/bin/npm -f ] && mv /usr/bin/npm /usr/bin/npm.old
+RUN sudo [ /usr/bin/npx -f ] && mv /usr/bin/npx /usr/bin/npx.old
 
 RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
  && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
@@ -527,10 +528,12 @@ RUN rm -fr vscode-lang-pack-install
 # RUN npm uninstall -g vsce 
 
 # Still need to restore old node, npm, npx files in /usr/bin if they existed.
+RUN sudo [ /usr/bin/node.old -f ] && mv -f /usr/bin/node.old /usr/bin/node
+RUN sudo [ /usr/bin/npm.old -f ] && mv -f /usr/bin/npm.old /usr/bin/npm
+RUN sudo [ /usr/bin/npx.old -f ] && mv -f /usr/bin/npx.old /usr/bin/npx
 
 RUN fix-permissions $XDG_DATA_HOME 
 RUN clean-layer.sh
-
 
 
 #QGIS

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -481,8 +481,7 @@ RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vs
 RUN cd vscode-loc 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
 
-RUN ls .
-RUN ls ./i18n
+RUN ls -R .
 
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -493,8 +493,10 @@ RUN which npm \
 # RUN bsdtar -xf nodejs-archive nodejs 
 # WORKDIR "nodejs"
 
-RUN npm install -g @vscode/vsce
-# RUN ls
+# RUN npm install -g @vscode/vsce
+
+# Going to try the original version again to see if it works with the updated base image.
+RUN npm install -g --unsafe-perm vsce@1.103.1
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -477,8 +477,8 @@ RUN rm ms-python-release.vsix
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
-RUN npm list | grep "stream"
-RUN npm list -g | grep "stream" 
+RUN npm list #| grep "stream"
+#RUN npm list -g | grep "stream" 
 RUN npm install stream
 
 ENV VS_FRENCH_VERSION="1.68.3" 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -482,7 +482,8 @@ ENV VS_FRENCH_VERSION="1.68.3"
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 
 # The branch specified in the -b option might not be set correctly.
-RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
+# RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
+RUN git clone https://github.com/microsoft/vscode-loc.git
 
 RUN pwd
 RUN tree -d
@@ -490,6 +491,8 @@ RUN stat vscode-loc
 
 RUN sudo cd vscode-loc
 RUN pwd
+
+
 
 RUN sudo cd i18n/vscode-language-pack-fr 
 RUN vsce package 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -476,40 +476,42 @@ RUN bsdtar -xf ms-python-release.vsix extension
 RUN rm ms-python-release.vsix 
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
-RUN npm install -g --unsafe-perm vsce@1.103.1 
-RUN npm list #| grep "stream"
-#RUN npm list -g | grep "stream" 
+RUN which npm \
+    && npm --version \
+    && which node \
+    && node --version
+
+RUN npm install -g @vscode/vsce
 RUN npm install -g stream
+RUN npm list -g 
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 
-
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
-RUN pwd
-RUN tree -d
-
-RUN stat vscode-loc
-RUN whoami
+RUN pwd \
+    && tree -d \
+    && stat vscode-loc \
+    && whoami \
 
 WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
-RUN pwd
-RUN which vsce
-RUN ls -al
-RUN cat package.json
+RUN pwd \
+    && which vsce \
+    && ls -al \
+    && cat package.json \
 
-RUN vsce package 
-RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
-RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
-#RUN cd ../../../ 
-WORKDIR "/tmp"
+# RUN vsce package 
+# RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
+# RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
+# #RUN cd ../../../ 
+# WORKDIR "/tmp"
 
 # -fr option is required. git clone protects the directory and cannot delete it without -fr
-RUN rm -fr vscode-loc 
-RUN npm uninstall -g vsce 
-RUN fix-permissions $XDG_DATA_HOME 
-RUN clean-layer.sh
+# RUN rm -fr vscode-loc 
+# RUN npm uninstall -g vsce 
+# RUN fix-permissions $XDG_DATA_HOME 
+# RUN clean-layer.sh
 
 
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -476,16 +476,19 @@ RUN bsdtar -xf ms-python-release.vsix extension
 RUN rm ms-python-release.vsix 
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
+RUN npm install -g --unsafe-perm vsce@1.103.1 
+
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 
 # The branch specified in the -b option might not be set correctly.
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
-RUN npm install -g --unsafe-perm vsce@1.103.1 
+RUN apt install --yes tree
+RUN tree -d
 
 RUN cd ./vscode-loc
-RUN ls -al
+RUN pwd
 
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -494,7 +494,7 @@ ENV NODE_VERSION="v20.17.0"
 ENV NODE_VERSION_ARCH="node-v20.17.0-linux-x64"
 RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 
-RUN bsdtar -xfv $NODE_VERSION_ARCH.tar.xz
+RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH/bin
 
 RUN ln -sf bin/node /usr/bin/node \

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -510,7 +510,7 @@ RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FR
 #RUN cd ../../../ 
 WORKDIR "/tmp"
 
--fr option is required. git clone protects the directory and cannot delete it without -fr
+# -fr option is required. git clone protects the directory and cannot delete it without -fr
 RUN rm -fr vscode-loc 
 RUN npm uninstall -g vsce 
 RUN fix-permissions $XDG_DATA_HOME 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -214,6 +214,7 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version \
   && \
+    # Re-testing whether the build action throws a quarto related error...
     # quarto
     curl -sLO  ${QUARTO_URL}\
     && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -481,9 +481,8 @@ RUN npm install -g --unsafe-perm vsce@1.103.1
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 
-# The branch specified in the -b option might not be set correctly.
-# RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
-RUN git clone https://github.com/microsoft/vscode-loc.git
+
+RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
 RUN pwd
 RUN tree -d
@@ -491,11 +490,10 @@ RUN tree -d
 RUN stat vscode-loc
 RUN whoami
 
-#RUN cd vscode-loc
-WORKDIR "/tmp/vscode-loc"
+WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
 RUN pwd
+RUN which vsce
 
-WORKDIR i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -485,6 +485,7 @@ ENV VS_LOCALE_REPO_VERSION="1.68.3"
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
 RUN apt install --yes tree
+RUN pwd
 RUN tree -d
 
 RUN cd ./vscode-loc

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -480,6 +480,10 @@ ENV VS_LOCALE_REPO_VERSION="1.68.3"
 RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 RUN cd vscode-loc 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
+
+RUN ls .
+RUN ls ./i18n
+
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -462,31 +462,37 @@ RUN apt-get update --yes \
 # https://github.com/cdr/code-server/issues/171
 ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
 ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
-RUN \
-    cd $RESOURCES_PATH \
-    && mkdir -p $HOME/.local/share \
-    && mkdir -p $VSCODE_DIR/extensions \
-    && VS_PYTHON_VERSION="2020.5.86806" \
-    && wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix \
-    && echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - \
-    && bsdtar -xf ms-python-release.vsix extension \
-    && rm ms-python-release.vsix \
-    && mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION \
-    && VS_FRENCH_VERSION="1.68.3" \
-    && VS_LOCALE_REPO_VERSION="1.68.3" \
-    && git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git \
-    && cd vscode-loc \
-    && npm install -g --unsafe-perm vsce@1.103.1 \
-    && cd i18n/vscode-language-pack-fr \
-    && vsce package \
-    && bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension \
-    && mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION \
-    && cd ../../../ \
-    # -fr option is required. git clone protects the directory and cannot delete it without -fr
-    && rm -fr vscode-loc \
-    && npm uninstall -g vsce \
-    && fix-permissions $XDG_DATA_HOME \
-    && clean-layer.sh
+
+
+
+
+RUN cd $RESOURCES_PATH 
+RUN mkdir -p $HOME/.local/share 
+RUN mkdir -p $VSCODE_DIR/extensions 
+RUN VS_PYTHON_VERSION="2020.5.86806" 
+RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix 
+RUN echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - 
+RUN bsdtar -xf ms-python-release.vsix extension 
+RUN rm ms-python-release.vsix 
+RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
+RUN VS_FRENCH_VERSION="1.68.3" 
+RUN VS_LOCALE_REPO_VERSION="1.68.3" 
+RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
+RUN cd vscode-loc 
+RUN npm install -g --unsafe-perm vsce@1.103.1 
+RUN cd i18n/vscode-language-pack-fr 
+RUN vsce package 
+RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
+RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
+RUN cd ../../../ 
+# -fr option is required. git clone protects the directory and cannot delete it without -fr
+RUN rm -fr vscode-loc 
+RUN npm uninstall -g vsce 
+RUN fix-permissions $XDG_DATA_HOME 
+RUN clean-layer.sh
+
+
+
 
 #QGIS
 COPY qgis-2022.gpg.key $RESOURCES_PATH/qgis-2022.gpg.key

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -481,13 +481,15 @@ RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vs
 RUN cd vscode-loc 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
 
-RUN ls -R .
+RUN ls -Rd .
+RUN ls -Rd . | grep "vscode-language-pack-fr"
 
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
 RUN cd ../../../ 
+
 # -fr option is required. git clone protects the directory and cannot delete it without -fr
 RUN rm -fr vscode-loc 
 RUN npm uninstall -g vsce 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -212,15 +212,27 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version \
-  && \
-    # Re-testing whether the build action throws a quarto related error...
-    # quarto
-    curl -sLO  ${QUARTO_URL}\
-    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
-    && tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
-    && chmod +x quarto-${QUARTO_VERSION} \
-    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version 
+
+# Narrowing down which quarto related step throws an error:
+
+# Verify what shell variable resolved to:
+RUN echo ${QUARTO_URL}
+
+# Download quarto archive
+RUN curl -sLO  ${QUARTO_URL}
+
+# Verify checksum
+RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
+
+# Extract archive
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+
+# Change file modes
+RUN chmod +x quarto-${QUARTO_VERSION} 
+
+# Move binaries to /usr 
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/6_remote-desktop.Dockerfile

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -170,7 +170,7 @@ ARG ARGO_CLI_VERSION=v3.4.5
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_SHA=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1 
 
-ARG QUARTO_VERSION=1.5.52
+ENV QUARTO_VERSION=1.5.52
 ARG QUARTO_SHA=d4d47989181d49ea48907f8aee32d7fc3823955885a9bab7b07afad2dccf4451
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -513,9 +513,9 @@ RUN node --version \
 
 RUN npm install @vscode/vsce
 
-WORKDIR tmp/vscode-lang-pack-install/vscode-loc/i18n/vscode-language-pack-fr 
+WORKDIR /tmp/vscode-lang-pack-install/vscode-loc/i18n/vscode-language-pack-fr 
 
-RUN npx tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package 
+RUN npx /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -479,7 +479,7 @@ RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION
 RUN npm install -g --unsafe-perm vsce@1.103.1 
 RUN npm list #| grep "stream"
 #RUN npm list -g | grep "stream" 
-RUN npm install stream
+RUN npm install -g stream
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -480,17 +480,12 @@ ENV VS_FRENCH_VERSION="1.68.3"
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 
 # The branch specified in the -b option might not be set correctly.
-RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
+RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
 
-RUN pwd
-RUN ls -Rd ./vscode-loc
-RUN which vsce
-
 RUN cd ./vscode-loc
-RUN git status
-RUN ls 
+RUN ls -al
 
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -298,13 +298,9 @@ RUN \
     # DB Utils
     apt-get install -y --no-install-recommends sqlitebrowser && \
     # Install nautilus and support for sftp mounting
-    apt-get install -y --no-install-recommends nautilus && \
+    apt-get install -y --no-install-recommends nautilus gvfs-backends && \
     # Install gigolo - Access remote systems
-    apt-get install -y --no-install-recommends gigolo && \
-
-    # Use a glob to grab all packages starting with gvfs, including gvfs-backends and any binaries
-    apt-get install -y --no-install-recommends gvfs* && \
-
+    apt-get install -y --no-install-recommends gigolo gvfs-bin && \
     # xfce systemload panel plugin - needs to be activated
     apt-get install -y --no-install-recommends xfce4-systemload-plugin && \
     # Leightweight ftp client that supports sftp, http, ...
@@ -407,7 +403,7 @@ RUN \
         bzip2 \
         lzop \
         libarchive-tools \
-        # zlibc \
+        zlibc \
         # unpack (almost) everything with one command
         unp \
         libbz2-dev \
@@ -419,9 +415,6 @@ RUN \
     fix-permissions && \
     # Cleanup
     clean-layer.sh
-
-# Again trying a wildcard to find any zlibc related package that might fit.
-RUN apt-get install -y --no-install-recommends zlibc*
 
 RUN pip3 install --quiet 'selenium' && \
     fix-permissions $CONDA_DIR && \

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -214,12 +214,6 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version 
 
-# Narrowing down which quarto related step throws an error:
-
-# Verify what shell variables resolve to:
-RUN echo ${QUARTO_VERSION}
-RUN echo ${QUARTO_URL}
-
 # Download quarto archive
 RUN curl -sLO  ${QUARTO_URL}
 
@@ -231,9 +225,6 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
-
-RUN sudo ls /usr/local/bin
-RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
 RUN sudo rm -f /usr/local/bin/quarto
@@ -506,21 +497,9 @@ RUN if [ -f /usr/bin/npx ]; then \
     sudo mv -f /usr/bin/npx /usr/bin/npx.old; \
     fi
 
-# RUN sudo [ /usr/bin/node -f ] && mv /usr/bin/node /usr/bin/node.old 
-# RUN sudo [ /usr/bin/npm -f ] && mv /usr/bin/npm /usr/bin/npm.old
-# RUN sudo [ /usr/bin/npx -f ] && mv /usr/bin/npx /usr/bin/npx.old
-
 RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
- && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
- && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
-
-# RUN sudo file /usr/bin/node \
-# && sudo file /usr/bin/npm \
-# && sudo file /usr/bin/npx
-
-# RUN node --version \
-# && npm --version \
-# && npx --version
+    && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
+    && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
 
 RUN npm install @vscode/vsce
 
@@ -536,10 +515,7 @@ RUN ls $VSCODE_DIR/extensions
 WORKDIR /tmp
 RUN rm -fr vscode-lang-pack-install
 
-# We don't need to bother since we deleted the entire node_modules subdirectory.
-# RUN npm uninstall -g vsce 
-
-# Still need to restore old node, npm, npx files in /usr/bin if they existed.
+# Restore old node, npm, npx files in /usr/bin if they existed.
 RUN if [ -f /usr/bin/node.old ]; then \
     sudo mv -f /usr/bin/node.old /usr/bin/node; \
     fi

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -497,9 +497,13 @@ RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH
 
-RUN ln -sf bin/node /usr/bin/node \
- && ln -sf bin/npm /usr/bin/npm \
- && ln -sf bin/npx /usr/bin/npx
+RUN ls .
+
+RUN sudo ln -sf bin/node /usr/bin/node \
+ && sudo ln -sf bin/npm /usr/bin/npm \
+ && sudo ln -sf bin/npx /usr/bin/npx
+
+RUN which node && which npm && which npx
 
 RUN npm install @vscode/vsce
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -487,14 +487,14 @@ RUN git clone https://github.com/microsoft/vscode-loc.git
 
 RUN pwd
 RUN tree -d
-RUN stat vscode-loc
 
-RUN sudo cd vscode-loc
+RUN stat vscode-loc
+RUN whoami
+
+RUN cd vscode-loc
 RUN pwd
 
-
-
-RUN sudo cd i18n/vscode-language-pack-fr 
+RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -212,23 +212,15 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version 
-
-# Download quarto archive
-RUN curl -sLO  ${QUARTO_URL}
-
-# Verify checksum
-RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
-
-# Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
-
-# Change file modes
-RUN chmod +x quarto-${QUARTO_VERSION} 
-
-# Move binaries to /usr 
-RUN sudo rm -f /usr/local/bin/quarto
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version \
+  && \
+    # quarto archive
+    && curl -sLO  ${QUARTO_URL} \
+    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
+    && RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+    && chmod +x quarto-${QUARTO_VERSION} \
+    && sudo rm -f /usr/local/bin/quarto \
+    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/6_remote-desktop.Dockerfile
@@ -454,76 +446,64 @@ RUN apt-get update --yes \
 ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
 ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
 
-RUN cd $RESOURCES_PATH 
-RUN mkdir -p $HOME/.local/share 
-RUN mkdir -p $VSCODE_DIR/extensions 
+RUN cd $RESOURCES_PATH \
+ && mkdir -p $HOME/.local/share \
+ && mkdir -p $VSCODE_DIR/extensions 
 ENV VS_PYTHON_VERSION="2020.5.86806" 
-RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix 
-RUN echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - 
-RUN bsdtar -xf ms-python-release.vsix extension 
-RUN rm ms-python-release.vsix 
-RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
-
+RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix \
+ && echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - \
+ && bsdtar -xf ms-python-release.vsix extension \
+ && rm ms-python-release.vsix \
+ && mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
 WORKDIR /tmp/vscode-lang-pack-install
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
-RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
-
 ENV NODE_VERSION="v20.17.0"
 ENV NODE_VERSION_ARCH="node-v20.17.0-linux-x64"
-RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 
-RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
+RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git \
+ && curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz \
+ && bsdtar -xf $NODE_VERSION_ARCH.tar.xz
+
 WORKDIR $NODE_VERSION_ARCH
 
 RUN if [ -f /usr/bin/node ]; then \
     sudo mv -f /usr/bin/node /usr/bin/node.old; \
-    fi
-
-RUN if [ -f /usr/bin/npm ]; then \
+    fi \
+ && if [ -f /usr/bin/npm ]; then \
     sudo mv -f /usr/bin/npm /usr/bin/npm.old; \
-    fi
-
-RUN if [ -f /usr/bin/npx ]; then \
+    fi \
+ && if [ -f /usr/bin/npx ]; then \
     sudo mv -f /usr/bin/npx /usr/bin/npx.old; \
-    fi
-
-RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
-    && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
-    && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
-
-RUN npm install @vscode/vsce
+    fi \
+ && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
+ && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
+ && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx \
+ && npm install @vscode/vsce
 
 WORKDIR /tmp/vscode-lang-pack-install/vscode-loc/i18n/vscode-language-pack-fr 
 
-RUN npx /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package 
-RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
-RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
-
-# Verify that the language pack was in fact moved into the extensions directory:
-RUN ls $VSCODE_DIR/extensions
+RUN npx /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package \
+ && bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension \
+ && mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION \
+ && ls $VSCODE_DIR/extensions
 
 WORKDIR /tmp
-RUN rm -fr vscode-lang-pack-install
 
-# Restore old node, npm, npx files in /usr/bin if they existed.
-RUN if [ -f /usr/bin/node.old ]; then \
+RUN rm -fr vscode-lang-pack-install \
+ && if [ -f /usr/bin/node.old ]; then \
     sudo mv -f /usr/bin/node.old /usr/bin/node; \
-    fi
-
-RUN if [ -f /usr/bin/npm.old ]; then \
+    fi \
+ && if [ -f /usr/bin/npm.old ]; then \
     sudo mv -f /usr/bin/npm.old /usr/bin/npm; \
-    fi
-
-RUN if [ -f /usr/bin/npx.old ]; then \
+    fi \
+ && if [ -f /usr/bin/npx.old ]; then \
     sudo mv -f /usr/bin/npx.old /usr/bin/npx; \
-    fi
-
-RUN fix-permissions $XDG_DATA_HOME 
-RUN clean-layer.sh
-
+    fi \
+ && fix-permissions $XDG_DATA_HOME \
+ && clean-layer.sh
 
 #QGIS
 COPY qgis-2022.gpg.key $RESOURCES_PATH/qgis-2022.gpg.key

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -499,11 +499,16 @@ WORKDIR $NODE_VERSION_ARCH
 
 RUN ls .
 
-RUN sudo ln -sf bin/node /usr/bin/node \
- && sudo ln -sf bin/npm /usr/bin/npm \
- && sudo ln -sf bin/npx /usr/bin/npx
+RUN sudo ln -sfv bin/node /usr/bin/node \
+ && sudo ln -sfv bin/npm /usr/bin/npm \
+ && sudo ln -sfv bin/npx /usr/bin/npx
 
-RUN which node && which npm && which npx
+RUN sudo ls /usr/bin
+RUN which node
+RUN which npm
+RUN which npx
+
+#RUN which node && which npm && which npx
 
 RUN npm install @vscode/vsce
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -495,15 +495,15 @@ RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
 WORKDIR $NODE_VERSION_ARCH
 
 RUN if [ -f /usr/bin/node ]; then \
-    sudo mv -f /usr/bin/node /usr/bin/node.old \
+    sudo mv -f /usr/bin/node /usr/bin/node.old; \
     fi
 
 RUN if [ -f /usr/bin/npm ]; then \
-    sudo mv -f /usr/bin/npm /usr/bin/npm.old \
+    sudo mv -f /usr/bin/npm /usr/bin/npm.old; \
     fi
 
 RUN if [ -f /usr/bin/npx ]; then \
-    sudo mv -f /usr/bin/npx /usr/bin/npx.old \
+    sudo mv -f /usr/bin/npx /usr/bin/npx.old; \
     fi
 
 # RUN sudo [ /usr/bin/node -f ] && mv /usr/bin/node /usr/bin/node.old 
@@ -541,15 +541,15 @@ RUN rm -fr vscode-lang-pack-install
 
 # Still need to restore old node, npm, npx files in /usr/bin if they existed.
 RUN if [ -f /usr/bin/node.old ]; then \
-    sudo mv -f /usr/bin/node.old /usr/bin/node \
+    sudo mv -f /usr/bin/node.old /usr/bin/node; \
     fi
 
 RUN if [ -f /usr/bin/npm.old ]; then \
-    sudo mv -f /usr/bin/npm.old /usr/bin/npm \
+    sudo mv -f /usr/bin/npm.old /usr/bin/npm; \
     fi
 
 RUN if [ -f /usr/bin/npx.old ]; then \
-    sudo mv -f /usr/bin/npx.old /usr/bin/npx \
+    sudo mv -f /usr/bin/npx.old /usr/bin/npx; \
     fi
 
 RUN fix-permissions $XDG_DATA_HOME 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -484,11 +484,10 @@ ENV VS_LOCALE_REPO_VERSION="1.68.3"
 # The branch specified in the -b option might not be set correctly.
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
-RUN apt install --yes tree
 RUN pwd
 RUN tree -d
 
-RUN cd ./vscode-loc
+RUN cd vscode-loc
 RUN pwd
 
 RUN cd i18n/vscode-language-pack-fr 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -472,8 +472,6 @@ RUN apt-get update --yes \
 ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
 ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
 
-
-
 RUN cd $RESOURCES_PATH 
 RUN mkdir -p $HOME/.local/share 
 RUN mkdir -p $VSCODE_DIR/extensions 
@@ -484,44 +482,39 @@ RUN bsdtar -xf ms-python-release.vsix extension
 RUN rm ms-python-release.vsix 
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
-RUN which npm \
-    && npm --version \
-    && which node \
-    && node --version
 
-# RUN curl -o nodejs-archive https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux-x64.tar.xz
-# RUN bsdtar -xf nodejs-archive nodejs 
-# WORKDIR "nodejs"
 
-# RUN npm install -g @vscode/vsce
-
-# Going to try the original version again to see if it works with the updated base image.
-RUN npm install -g --unsafe-perm vsce@1.103.1
+WORKDIR /tmp/vscode-lang-pack-install
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
-#RUN pwd \
-#    && tree -d \
-#    && stat vscode-loc \
-#    && whoami \
-#
-WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
-#RUN pwd \
-#    && which vsce \
-#    && ls -al \
-#    && cat package.json \
+ENV NODE_VERSION="v20.17.0"
+ENV NODE_VERSION_ARCH="node-v20.17.0-linux-x64"
+RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 
-RUN vsce package 
+RUN bsdtar -xfv $NODE_VERSION_ARCH.tar.xz
+WORKDIR $NODE_VERSION_ARCH/bin
+
+RUN ln -sf bin/node /usr/bin/node
+ && ln -sf bin/npm /usr/bin/npm
+ && ln -sf bin/npx /usr/bin/npx
+
+RUN npm install @vscode/vsce
+
+WORKDIR tmp/vscode-lang-pack-install/vscode-loc/i18n/vscode-language-pack-fr 
+
+RUN npx tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
-#RUN cd ../../../ 
-WORKDIR "/tmp"
 
-# -fr option is required. git clone protects the directory and cannot delete it without -fr
-RUN rm -fr vscode-loc 
+WORKDIR /tmp
+RUN rm -fr vscode-lang-pack-install
 RUN npm uninstall -g vsce 
+
+# Still need to restore old node, npm, npx files in /usr/bin if they existed.
+
 RUN fix-permissions $XDG_DATA_HOME 
 RUN clean-layer.sh
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -227,7 +227,7 @@ RUN curl -sLO  ${QUARTO_URL}
 RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
 
 # Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -477,6 +477,7 @@ RUN rm ms-python-release.vsix
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
 
 RUN npm install -g --unsafe-perm vsce@1.103.1 
+RUN npm install @types/node
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -494,6 +494,8 @@ RUN whoami
 WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
 RUN pwd
 RUN which vsce
+RUN ls -al
+RUN cat package.json
 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -481,25 +481,30 @@ RUN which npm \
     && which node \
     && node --version
 
-RUN npm install -g @vscode/vsce
-RUN npm install -g stream
-RUN npm list -g 
+RUN curl -o nodejs-archive https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux-x64.tar.xz
+RUN bsdtar -xf nodejs-archive nodejs 
+WORKDIR "nodejs"
+
+RUN npm install @vscode/vsce
+RUN ls
+
+
+
 
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
-
 RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 
-RUN pwd \
-    && tree -d \
-    && stat vscode-loc \
-    && whoami \
-
-WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
-RUN pwd \
-    && which vsce \
-    && ls -al \
-    && cat package.json \
+#RUN pwd \
+#    && tree -d \
+#    && stat vscode-loc \
+#    && whoami \
+#
+#WORKDIR vscode-loc/i18n/vscode-language-pack-fr 
+#RUN pwd \
+#    && which vsce \
+#    && ls -al \
+#    && cat package.json \
 
 # RUN vsce package 
 # RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -469,7 +469,7 @@ ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
 RUN cd $RESOURCES_PATH 
 RUN mkdir -p $HOME/.local/share 
 RUN mkdir -p $VSCODE_DIR/extensions 
-RUN VS_PYTHON_VERSION="2020.5.86806" 
+ENV VS_PYTHON_VERSION="2020.5.86806" 
 RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix 
 RUN echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - 
 RUN bsdtar -xf ms-python-release.vsix extension 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -236,7 +236,7 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/6_remote-desktop.Dockerfile

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -503,12 +503,13 @@ RUN sudo ln -sfv bin/node /usr/bin/node \
  && sudo ln -sfv bin/npm /usr/bin/npm \
  && sudo ln -sfv bin/npx /usr/bin/npx
 
-RUN sudo ls /usr/bin
-RUN which node
-RUN which npm
-RUN which npx
+RUN sudo file /usr/bin/node \
+ && sudo file /usr/bin/npm \
+ && sudo file /usr/bin/npx
 
-#RUN which node && which npm && which npx
+RUN node --version \
+ && npm --version \
+ && npx --version
 
 RUN npm install @vscode/vsce
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -6,9 +6,7 @@
 # Rocker/geospatial is tagged by R version number.  They are not clear on whether they'll change those tagged
 # images for hotfixes, so always pin tag and digest to prevent unexpected upstream changes
 
-FROM rocker/geospatial
-# Unpinning version to see if it resolves the vscode extension pack install problems.
-#:4.2.1@sha256:5caca36b8962233f8636540b7c349d3f493f09e864b6e278cb46946ccf60d4d2
+FROM rocker/geospatial:4.2.1@sha256:5caca36b8962233f8636540b7c349d3f493f09e864b6e278cb46946ccf60d4d2
 
 # For compatibility with docker stacks
 ARG HOME=/home/$NB_USER
@@ -499,9 +497,9 @@ WORKDIR $NODE_VERSION_ARCH
 
 RUN ls .
 
-RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node 
-RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm 
-RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
+RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
+ && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
+ && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
 
 RUN sudo file /usr/bin/node \
  && sudo file /usr/bin/npm \
@@ -518,6 +516,9 @@ WORKDIR /tmp/vscode-lang-pack-install/vscode-loc/i18n/vscode-language-pack-fr
 RUN npx /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/node_modules/@vscode/vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 
+
+# Verify that the language pack was in fact moved into the extensions directory:
+RUN ls $VSCODE_DIR/extensions
 
 WORKDIR /tmp
 RUN rm -fr vscode-lang-pack-install

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -500,8 +500,8 @@ WORKDIR $NODE_VERSION_ARCH
 RUN ls .
 
 RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node 
-RUN sudo ln -sfv ./bin/npm /usr/bin/npm 
-RUN sudo ln -sfv bin/npx /usr/bin/npx
+RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm 
+RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx
 
 RUN sudo file /usr/bin/node \
  && sudo file /usr/bin/npm \
@@ -521,7 +521,9 @@ RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FR
 
 WORKDIR /tmp
 RUN rm -fr vscode-lang-pack-install
-RUN npm uninstall -g vsce 
+
+# We don't need to bother since we deleted the entire node_modules subdirectory.
+# RUN npm uninstall -g vsce 
 
 # Still need to restore old node, npm, npx files in /usr/bin if they existed.
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -486,11 +486,12 @@ RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/v
 
 RUN pwd
 RUN tree -d
+RUN stat vscode-loc
 
-RUN cd vscode-loc
+RUN sudo cd vscode-loc
 RUN pwd
 
-RUN cd i18n/vscode-language-pack-fr 
+RUN sudo cd i18n/vscode-language-pack-fr 
 RUN vsce package 
 RUN bsdtar -xf vscode-language-pack-fr-$VS_FRENCH_VERSION.vsix extension 
 RUN mv extension $VSCODE_DIR/extensions/ms-ceintl.vscode-language-pack-fr-$VS_FRENCH_VERSION 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -495,7 +495,7 @@ ENV NODE_VERSION_ARCH="node-v20.17.0-linux-x64"
 RUN curl -O https://nodejs.org/dist/$NODE_VERSION/$NODE_VERSION_ARCH.tar.xz
 
 RUN bsdtar -xf $NODE_VERSION_ARCH.tar.xz
-WORKDIR $NODE_VERSION_ARCH/bin
+WORKDIR $NODE_VERSION_ARCH
 
 RUN ln -sf bin/node /usr/bin/node \
  && ln -sf bin/npm /usr/bin/npm \

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -170,7 +170,7 @@ ARG ARGO_CLI_VERSION=v3.4.5
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_SHA=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1 
 
-ARG QUARTO_VERSION="1.5.52"
+ENV QUARTO_VERSION=1.5.52
 ARG QUARTO_SHA=d4d47989181d49ea48907f8aee32d7fc3823955885a9bab7b07afad2dccf4451
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -314,7 +314,7 @@ RUN \
     apt-get install -y --no-install-recommends gigolo && \
 
     # See if we can install whatever version of gvfs-bin that is available
-    apt-get install -y -no-install-recommends gvfs-bin* && \
+    apt-get install -y --no-install-recommends gvfs-bin* && \
 
     # xfce systemload panel plugin - needs to be activated
     apt-get install -y --no-install-recommends xfce4-systemload-plugin && \

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -216,7 +216,8 @@ RUN \
 
 # Narrowing down which quarto related step throws an error:
 
-# Verify what shell variable resolved to:
+# Verify what shell variables resolve to:
+RUN echo ${QUARTO_VERSION}
 RUN echo ${QUARTO_URL}
 
 # Download quarto archive

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -475,14 +475,18 @@ RUN echo "${SHA256py} ms-python-release.vsix" | sha256sum -c -
 RUN bsdtar -xf ms-python-release.vsix extension 
 RUN rm ms-python-release.vsix 
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
+
 ENV VS_FRENCH_VERSION="1.68.3" 
 ENV VS_LOCALE_REPO_VERSION="1.68.3" 
+
+# The branch specified in the -b option might not be set correctly.
 RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
-RUN cd vscode-loc 
+
 RUN npm install -g --unsafe-perm vsce@1.103.1 
 
-RUN ls -Rd .
-RUN ls -Rd . | grep "vscode-language-pack-fr"
+RUN pwd
+RUN ls -Rd ./vscode-loc
+RUN which vsce
 
 RUN cd i18n/vscode-language-pack-fr 
 RUN vsce package 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -309,12 +309,12 @@ RUN \
     # DB Utils
     apt-get install -y --no-install-recommends sqlitebrowser && \
     # Install nautilus and support for sftp mounting
-    apt-get install -y --no-install-recommends nautilus gvfs-backends && \
+    apt-get install -y --no-install-recommends nautilus && \
     # Install gigolo - Access remote systems
     apt-get install -y --no-install-recommends gigolo && \
 
-    # See if we can install whatever version of gvfs-bin that is available
-    apt-get install -y --no-install-recommends gvfs-bin* && \
+    # Use a glob to grab all packages starting with gvfs, including gvfs-backends and any binaries
+    apt-get install -y --no-install-recommends gvfs* && \
 
     # xfce systemload panel plugin - needs to be activated
     apt-get install -y --no-install-recommends xfce4-systemload-plugin && \

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -499,9 +499,9 @@ WORKDIR $NODE_VERSION_ARCH
 
 RUN ls .
 
-RUN sudo ln -sfv bin/node /usr/bin/node \
- && sudo ln -sfv bin/npm /usr/bin/npm \
- && sudo ln -sfv bin/npx /usr/bin/npx
+RUN sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node 
+RUN sudo ln -sfv ./bin/npm /usr/bin/npm 
+RUN sudo ln -sfv bin/npx /usr/bin/npx
 
 RUN sudo file /usr/bin/node \
  && sudo file /usr/bin/npm \

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -475,8 +475,8 @@ RUN echo "${SHA256py} ms-python-release.vsix" | sha256sum -c -
 RUN bsdtar -xf ms-python-release.vsix extension 
 RUN rm ms-python-release.vsix 
 RUN mv extension $VSCODE_DIR/extensions/ms-python.python-$VS_PYTHON_VERSION 
-RUN VS_FRENCH_VERSION="1.68.3" 
-RUN VS_LOCALE_REPO_VERSION="1.68.3" 
+ENV VS_FRENCH_VERSION="1.68.3" 
+ENV VS_LOCALE_REPO_VERSION="1.68.3" 
 RUN git clone -b release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/vscode-loc.git 
 RUN cd vscode-loc 
 RUN npm install -g --unsafe-perm vsce@1.103.1 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -232,6 +232,9 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
 
+RUN sudo ls /usr/local/bin
+RUN sudo file /usr/local/bin/quarto
+
 # Move binaries to /usr 
 RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -170,7 +170,7 @@ ARG ARGO_CLI_VERSION=v3.4.5
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_SHA=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1 
 
-ARG QUARTO_VERSION=1.5.52
+ARG QUARTO_VERSION="1.5.52"
 ARG QUARTO_SHA=d4d47989181d49ea48907f8aee32d7fc3823955885a9bab7b07afad2dccf4451
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -141,7 +141,8 @@ RUN \
 
 # Narrowing down which quarto related step throws an error:
 
-# Verify what shell variable resolved to:
+# Verify what shell variables resolve to:
+RUN echo ${QUARTO_VERSION}
 RUN echo ${QUARTO_URL}
 
 # Download quarto archive

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -137,15 +137,27 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version \
-  && \
-    # Re-testing whether the build action throws a quarto related error...
-    # quarto
-    curl -sLO  ${QUARTO_URL}\
-    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
-    && tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
-    && chmod +x quarto-${QUARTO_VERSION} \
-    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version 
+
+# Narrowing down which quarto related step throws an error:
+
+# Verify what shell variable resolved to:
+RUN echo ${QUARTO_URL}
+
+# Download quarto archive
+RUN curl -sLO  ${QUARTO_URL}
+
+# Verify checksum
+RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
+
+# Extract archive
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+
+# Change file modes
+RUN chmod +x quarto-${QUARTO_VERSION} 
+
+# Move binaries to /usr 
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -157,6 +157,9 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
 
+RUN sudo ls /usr/local/bin
+RUN sudo file /usr/local/bin/quarto
+
 # Move binaries to /usr 
 RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -137,23 +137,15 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version 
-
-# Download quarto archive
-RUN curl -sLO  ${QUARTO_URL}
-
-# Verify checksum
-RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
-
-# Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
-
-# Change file modes
-RUN chmod +x quarto-${QUARTO_VERSION} 
-
-# Move binaries to /usr 
-RUN sudo rm -f /usr/local/bin/quarto
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version \
+  && \
+    # quarto archive
+    && curl -sLO  ${QUARTO_URL} \
+    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
+    && RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+    && chmod +x quarto-${QUARTO_VERSION} \
+    && sudo rm -f /usr/local/bin/quarto \
+    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -161,7 +161,7 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -161,7 +161,8 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo rm -f /usr/local/bin/quarto
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -139,6 +139,7 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version \
   && \
+    # Re-testing whether the build action throws a quarto related error...
     # quarto
     curl -sLO  ${QUARTO_URL}\
     && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -152,7 +152,7 @@ RUN curl -sLO  ${QUARTO_URL}
 RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
 
 # Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -95,7 +95,7 @@ ARG ARGO_CLI_VERSION=v3.4.5
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_SHA=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1 
 
-ARG QUARTO_VERSION=1.5.52
+ENV QUARTO_VERSION=1.5.52
 ARG QUARTO_SHA=d4d47989181d49ea48907f8aee32d7fc3823955885a9bab7b07afad2dccf4451
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -139,12 +139,6 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version 
 
-# Narrowing down which quarto related step throws an error:
-
-# Verify what shell variables resolve to:
-RUN echo ${QUARTO_VERSION}
-RUN echo ${QUARTO_URL}
-
 # Download quarto archive
 RUN curl -sLO  ${QUARTO_URL}
 
@@ -156,9 +150,6 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
-
-RUN sudo ls /usr/local/bin
-RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
 RUN sudo rm -f /usr/local/bin/quarto

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -138,15 +138,27 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version \
-  && \
-    # Re-testing whether the build action throws a quarto related error...
-    # quarto
-    curl -sLO  ${QUARTO_URL}\
-    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
-    && tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
-    && chmod +x quarto-${QUARTO_VERSION} \
-    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version 
+
+# Narrowing down which quarto related step throws an error:
+
+# Verify what shell variable resolved to:
+RUN echo ${QUARTO_URL}
+
+# Download quarto archive
+RUN curl -sLO  ${QUARTO_URL}
+
+# Verify checksum
+RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
+
+# Extract archive
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+
+# Change file modes
+RUN chmod +x quarto-${QUARTO_VERSION} 
+
+# Move binaries to /usr 
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -158,6 +158,9 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
 
+RUN sudo ls /usr/local/bin
+RUN sudo file /usr/local/bin/quarto
+
 # Move binaries to /usr 
 RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -140,6 +140,7 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version \
   && \
+    # Re-testing whether the build action throws a quarto related error...
     # quarto
     curl -sLO  ${QUARTO_URL}\
     && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -162,7 +162,7 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -138,23 +138,15 @@ RUN \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
-    && argo version 
-
-# Download quarto archive
-RUN curl -sLO  ${QUARTO_URL}
-
-# Verify checksum
-RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
-
-# Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
-
-# Change file modes
-RUN chmod +x quarto-${QUARTO_VERSION} 
-
-# Move binaries to /usr 
-RUN sudo rm -f /usr/local/bin/quarto
-RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && argo version \
+  && \
+    # quarto archive
+    && curl -sLO  ${QUARTO_URL} \
+    && echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - \
+    && RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+    && chmod +x quarto-${QUARTO_VERSION} \
+    && sudo rm -f /usr/local/bin/quarto \
+    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -140,12 +140,6 @@ RUN \
     && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version 
 
-# Narrowing down which quarto related step throws an error:
-
-# Verify what shell variables resolve to:
-RUN echo ${QUARTO_VERSION}
-RUN echo ${QUARTO_URL}
-
 # Download quarto archive
 RUN curl -sLO  ${QUARTO_URL}
 
@@ -157,9 +151,6 @@ RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 
-
-RUN sudo ls /usr/local/bin
-RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
 RUN sudo rm -f /usr/local/bin/quarto

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -153,7 +153,7 @@ RUN curl -sLO  ${QUARTO_URL}
 RUN echo "${QUARTO_SHA}  quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"  | sha256sum -c - 
 
 # Extract archive
-RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
+RUN tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz 
 
 # Change file modes
 RUN chmod +x quarto-${QUARTO_VERSION} 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -142,7 +142,8 @@ RUN \
 
 # Narrowing down which quarto related step throws an error:
 
-# Verify what shell variable resolved to:
+# Verify what shell variables resolve to:
+RUN echo ${QUARTO_VERSION}
 RUN echo ${QUARTO_URL}
 
 # Download quarto archive

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -96,7 +96,7 @@ ARG ARGO_CLI_VERSION=v3.4.5
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_SHA=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1 
 
-ARG QUARTO_VERSION=1.5.52
+ENV QUARTO_VERSION=1.5.52
 ARG QUARTO_SHA=d4d47989181d49ea48907f8aee32d7fc3823955885a9bab7b07afad2dccf4451
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -162,7 +162,8 @@ RUN sudo ls /usr/local/bin
 RUN sudo file /usr/local/bin/quarto
 
 # Move binaries to /usr 
-RUN sudo mv -f ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+RUN sudo rm -f /usr/local/bin/quarto
+RUN sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile


### PR DESCRIPTION
# Description

**What your PR adds/fixes/removes**

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
