### PR TITLE
Updates the makefile docker buildkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ __pycache__
 .ipynb_checkpoints/
 .idea
 node_modules
-github_output.log
 package-lock.json
 package.json

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ build/%: ## build the latest image
 	# End repo with exactly one trailing slash, unless it is empty
 	REPO=$$(echo "$(REPO)" | sed 's:/*$$:/:' | sed 's:^\s*/*\s*$$::') &&\
 	IMAGE_NAME="$${REPO}$(notdir $@):$(TAG)" && \
-	docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
+	docker build $(DARGS) --build-arg BUILDKIT_PARALLELISM=1 --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
 	echo "full_image_name=$$IMAGE_NAME" >> $(GITHUB_OUTPUT) && \

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ build/%: ## build the latest image
 	# End repo with exactly one trailing slash, unless it is empty
 	REPO=$$(echo "$(REPO)" | sed 's:/*$$:/:' | sed 's:^\s*/*\s*$$::') &&\
 	IMAGE_NAME="$${REPO}$(notdir $@):$(TAG)" && \
-	docker build $(DARGS) --build-arg --memory=4g --memory-swap=8g --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
+	docker build $(DARGS) --no-cache --output=type=docker --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
 	echo "full_image_name=$$IMAGE_NAME" >> $(GITHUB_OUTPUT) && \

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ build/%: ## build the latest image
 	# End repo with exactly one trailing slash, unless it is empty
 	REPO=$$(echo "$(REPO)" | sed 's:/*$$:/:' | sed 's:^\s*/*\s*$$::') &&\
 	IMAGE_NAME="$${REPO}$(notdir $@):$(TAG)" && \
-	docker build $(DARGS) --build-arg BUILDKIT_PARALLELISM=1 --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
+	docker build $(DARGS) --build-arg --memory=4g --memory-swap=8g --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
 	echo "full_image_name=$$IMAGE_NAME" >> $(GITHUB_OUTPUT) && \

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ build/%: ## build the latest image
 	# End repo with exactly one trailing slash, unless it is empty
 	REPO=$$(echo "$(REPO)" | sed 's:/*$$:/:' | sed 's:^\s*/*\s*$$::') &&\
 	IMAGE_NAME="$${REPO}$(notdir $@):$(TAG)" && \
-	DOCKER_BUILDKIT=0 docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
+	docker build $(DARGS) --rm --force-rm -t $$IMAGE_NAME ./output/$(notdir $@) && \
 	echo -n "Built image $$IMAGE_NAME of size: " && \
 	docker images $$IMAGE_NAME --format "{{.Size}}" && \
 	echo "full_image_name=$$IMAGE_NAME" >> $(GITHUB_OUTPUT) && \

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,7 @@ pull/%:
 	echo "Pulling $${REPO}$(notdir $@)$${TAG}" &&\
 	docker pull $(DARGS) "$${REPO}$(notdir $@)$${TAG}"
 
+build/%: GITHUB_OUTPUT ?= .tmp/github_output.log
 build/%: DARGS?=
 build/%: REPO?=$(DEFAULT_REPO)
 build/%: TAG?=$(DEFAULT_TAG)


### PR DESCRIPTION
~~fixes the issue with the `GITHUB_OUTPUT` variable from~~
moved to https://github.com/StatCan/aaw-kubeflow-containers/pull/680

Removes the `DOCKER_BUILDKIT=0`,
so that docker will no longer use the legacy build
https://github.com/StatCan/aaw-kubeflow-containers/issues/578