### PR TITLE
Update trivy

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -177,7 +177,7 @@ jobs:
       run: |
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+        trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
 
     # Push image to ACR
     # Pushes if this is a push to master or an update to a PR that has auto-deploy label

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -62,7 +62,7 @@ jobs:
       CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
       LOCAL_REPO: localhost:5000
       TRIVY_VERSION: "v0.56.2"
-      TRIVY_DATABASE: "public.ecr.aws/aquasecurity/trivy-db:2"
+      TRIVY_DATABASE: "ghcr.io/aquasecurity/trivy-db:2"
       HADOLINT_VERSION: "2.12.0"
       ACTIONS_RUNNER_DEBUG: true
 

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -62,8 +62,8 @@ jobs:
       CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
       LOCAL_REPO: localhost:5000
       TRIVY_VERSION: "v0.56.2"
-      TRIVY_DATABASE: "public.ecr.aws/aquasecurity/trivy-db"
-      TRIVY_JAVA_DATABASE: "public.ecr.aws/aquasecurity/trivy-java-db"
+      TRIVY_DATABASES: '"ghcr.io/aquasecurity/trivy-db:2","public.ecr.aws/aquasecurity/trivy-db"'
+      TRIVY_JAVA_DATABASES: '"ghcr.io/aquasecurity/trivy-java-db:1","public.ecr.aws/aquasecurity/trivy-java-db"'
       HADOLINT_VERSION: "2.12.0"
       ACTIONS_RUNNER_DEBUG: true
 
@@ -180,8 +180,8 @@ jobs:
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
         trivy image \
-          --db-repository ${{ env.TRIVY_DATABASE }} \
-          --java-db-repository ${{ env.TRIVY_JAVA_DATABASE }} \
+          --db-repository ${{ env.TRIVY_DATABASES }} \
+          --java-db-repository ${{ env.TRIVY_JAVA_DATABASES }} \
           ${{ steps.build-image.outputs.full_image_name }} \
           --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
 

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -178,7 +178,7 @@ jobs:
       run: |
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image --db-repository ${{ TRIVY_DATABASE }} ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
+        trivy image --db-repository ${{ env.TRIVY_DATABASE }} ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
 
     # Push image to ACR
     # Pushes if this is a push to master or an update to a PR that has auto-deploy label

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -61,7 +61,7 @@ jobs:
       CLUSTER_NAME: k8s-cancentral-01-covid-aks
       CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
       LOCAL_REPO: localhost:5000
-      TRIVY_VERSION: "v0.31.3"
+      TRIVY_VERSION: "v0.56.2"
       HADOLINT_VERSION: "2.12.0"
       ACTIONS_RUNNER_DEBUG: true
 
@@ -177,7 +177,7 @@ jobs:
       run: |
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+        trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
 
     # Push image to ACR
     # Pushes if this is a push to master or an update to a PR that has auto-deploy label

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -62,6 +62,7 @@ jobs:
       CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
       LOCAL_REPO: localhost:5000
       TRIVY_VERSION: "v0.56.2"
+      TRIVY_DATABASE: "public.ecr.aws/aquasecurity/trivy-db:2"
       HADOLINT_VERSION: "2.12.0"
       ACTIONS_RUNNER_DEBUG: true
 
@@ -177,7 +178,7 @@ jobs:
       run: |
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
+        trivy image --db-repository ${{ TRIVY_DATABASE }} ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
 
     # Push image to ACR
     # Pushes if this is a push to master or an update to a PR that has auto-deploy label

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -62,7 +62,8 @@ jobs:
       CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
       LOCAL_REPO: localhost:5000
       TRIVY_VERSION: "v0.56.2"
-      TRIVY_DATABASE: "ghcr.io/aquasecurity/trivy-db:2"
+      TRIVY_DATABASE: "public.ecr.aws/aquasecurity/trivy-db"
+      TRIVY_JAVA_DATABASE: "public.ecr.aws/aquasecurity/trivy-java-db"
       HADOLINT_VERSION: "2.12.0"
       ACTIONS_RUNNER_DEBUG: true
 
@@ -178,7 +179,11 @@ jobs:
       run: |
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image --db-repository ${{ env.TRIVY_DATABASE }} ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
+        trivy image \
+          --db-repository ${{ env.TRIVY_DATABASE }} \
+          --java-db-repository ${{ env.TRIVY_JAVA_DATABASE }} \
+          ${{ steps.build-image.outputs.full_image_name }} \
+          --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
 
     # Push image to ACR
     # Pushes if this is a push to master or an update to a PR that has auto-deploy label


### PR DESCRIPTION
Updates trivy to the latest version.
uses new `--db-repository` and `--java-db-repository` flags to point to point to multiple mirrors of the databases. 
This should mean many fewer `TOOMANYREQUESTS` errors. 