### PR TITLE
Test if changing ownership of user's home directory from root to user fixes byobu startup error.

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -171,13 +171,14 @@ jobs:
     - run: ./.github/scripts/cleanup_runner.sh
 
     # Scan image for vulnerabilities
-    - name: Aqua Security Trivy image scan
+    #- name: Aqua Security Trivy image scan
+    
     # see https://github.com/StatCan/aaw-private/issues/11 -- should be re-enabled
-      if: steps.notebook-name.outputs.NOTEBOOK_NAME != 'sas'
-      run: |
-        printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+    #  if: steps.notebook-name.outputs.NOTEBOOK_NAME != 'sas'
+    #  run: |
+    #    printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
+    #    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
+    #    trivy image ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
 
     # Push image to ACR
     # Pushes if this is a push to master or an update to a PR that has auto-deploy label

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -71,12 +71,12 @@ jobs:
         notebook:
           # TODO: Pull this from a settings file or Makefile, that way Make can have the same list
           # - docker-stacks-datascience-notebook # Debugging
-          - rstudio
-          - sas
+          # - rstudio
+          # - sas
           - jupyterlab-cpu
-          - jupyterlab-pytorch 
+          # - jupyterlab-pytorch 
           # - jupyterlab-tensorflow removed from build. https://jirab.statcan.ca/browse/BTIS-421
-          - remote-desktop 
+          # - remote-desktop 
     needs: pre-build-checks
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -71,12 +71,12 @@ jobs:
         notebook:
           # TODO: Pull this from a settings file or Makefile, that way Make can have the same list
           # - docker-stacks-datascience-notebook # Debugging
-          # - rstudio
-          # - sas
+          - rstudio
+          - sas
           - jupyterlab-cpu
-          # - jupyterlab-pytorch 
+          - jupyterlab-pytorch 
           # - jupyterlab-tensorflow removed from build. https://jirab.statcan.ca/browse/BTIS-421
-          # - remote-desktop 
+          - remote-desktop 
     needs: pre-build-checks
     runs-on: ubuntu-latest
     services:
@@ -171,14 +171,13 @@ jobs:
     - run: ./.github/scripts/cleanup_runner.sh
 
     # Scan image for vulnerabilities
-    #- name: Aqua Security Trivy image scan
-    
+    - name: Aqua Security Trivy image scan
     # see https://github.com/StatCan/aaw-private/issues/11 -- should be re-enabled
-    #  if: steps.notebook-name.outputs.NOTEBOOK_NAME != 'sas'
-    #  run: |
-    #    printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
-    #    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-    #    trivy image ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+      if: steps.notebook-name.outputs.NOTEBOOK_NAME != 'sas'
+      run: |
+        printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
+        trivy image ${{ steps.build-image.outputs.full_image_name }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
 
     # Push image to ACR
     # Pushes if this is a push to master or an update to a PR that has auto-deploy label

--- a/docker-bits/∞_CMD.Dockerfile
+++ b/docker-bits/∞_CMD.Dockerfile
@@ -27,6 +27,9 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
+# Confirm if ownership change of /home/jovyan will fix the byobu error.
+RUN chown $NB_USER:users /home/$NB_USER
+
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]
 CMD ["start-custom.sh"]

--- a/docker-bits/∞_CMD.Dockerfile
+++ b/docker-bits/∞_CMD.Dockerfile
@@ -27,6 +27,7 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
+
 # Confirm if ownership change of /home/jovyan will fix the byobu error.
 RUN chown $NB_USER:users /home/$NB_USER
 

--- a/docker-bits/∞_CMD.Dockerfile
+++ b/docker-bits/∞_CMD.Dockerfile
@@ -27,7 +27,7 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
-# Confirm if ownership change of /home/jovyan will fix the byobu error.
+# Assign ownership of user's home directory to user
 RUN chown $NB_USER:users /home/$NB_USER
 
 USER $NB_USER

--- a/docker-bits/∞_CMD.Dockerfile
+++ b/docker-bits/∞_CMD.Dockerfile
@@ -27,7 +27,6 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
-
 # Confirm if ownership change of /home/jovyan will fix the byobu error.
 RUN chown $NB_USER:users /home/$NB_USER
 

--- a/output/docker-stacks-datascience-notebook/Dockerfile
+++ b/output/docker-stacks-datascience-notebook/Dockerfile
@@ -33,6 +33,9 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
+# Confirm if ownership change of /home/jovyan will fix the byobu error.
+RUN chown $NB_USER:users /home/$NB_USER
+
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]
 CMD ["start-custom.sh"]

--- a/output/docker-stacks-datascience-notebook/Dockerfile
+++ b/output/docker-stacks-datascience-notebook/Dockerfile
@@ -33,7 +33,7 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
-# Confirm if ownership change of /home/jovyan will fix the byobu error.
+# Assign ownership of user's home directory to user
 RUN chown $NB_USER:users /home/$NB_USER
 
 USER $NB_USER

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -396,7 +396,7 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
-# Confirm if ownership change of /home/jovyan will fix the byobu error.
+# Assign ownership of user's home directory to user
 RUN chown $NB_USER:users /home/$NB_USER
 
 USER $NB_USER

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -396,6 +396,9 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
+# Confirm if ownership change of /home/jovyan will fix the byobu error.
+RUN chown $NB_USER:users /home/$NB_USER
+
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]
 CMD ["start-custom.sh"]

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -418,7 +418,7 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
-# Confirm if ownership change of /home/jovyan will fix the byobu error.
+# Assign ownership of user's home directory to user
 RUN chown $NB_USER:users /home/$NB_USER
 
 USER $NB_USER

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -418,6 +418,9 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
+# Confirm if ownership change of /home/jovyan will fix the byobu error.
+RUN chown $NB_USER:users /home/$NB_USER
+
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]
 CMD ["start-custom.sh"]

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -525,6 +525,9 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
+# Confirm if ownership change of /home/jovyan will fix the byobu error.
+RUN chown $NB_USER:users /home/$NB_USER
+
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]
 CMD ["start-custom.sh"]

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -525,7 +525,7 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
-# Confirm if ownership change of /home/jovyan will fix the byobu error.
+# Assign ownership of user's home directory to user
 RUN chown $NB_USER:users /home/$NB_USER
 
 USER $NB_USER

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -282,6 +282,9 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
+# Confirm if ownership change of /home/jovyan will fix the byobu error.
+RUN chown $NB_USER:users /home/$NB_USER
+
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]
 CMD ["start-custom.sh"]

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -282,7 +282,7 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
-# Confirm if ownership change of /home/jovyan will fix the byobu error.
+# Assign ownership of user's home directory to user
 RUN chown $NB_USER:users /home/$NB_USER
 
 USER $NB_USER

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -496,7 +496,7 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
-# Confirm if ownership change of /home/jovyan will fix the byobu error.
+# Assign ownership of user's home directory to user
 RUN chown $NB_USER:users /home/$NB_USER
 
 USER $NB_USER

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -496,6 +496,9 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-forge-nvidia --system && \
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
+# Confirm if ownership change of /home/jovyan will fix the byobu error.
+RUN chown $NB_USER:users /home/$NB_USER
+
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]
 CMD ["start-custom.sh"]


### PR DESCRIPTION
… fixes byobu error.

# Description

**What your PR adds/fixes/removes**

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
