### PR TITLE
Add retry functionality to Trivy scan

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -187,7 +187,7 @@ jobs:
 
           trivy image \
             ${{ steps.build-image.outputs.full_image_name }} \
-            --exit-code 10 --timeout=20m --scanners vuln --severity CRITICAL
+            --exit-code 10 --timeout=20m --scanners vuln --severity CRITICAL || true
           EXIT_CODE=$?
 
           if [[ $EXIT_CODE -eq 0 ]]; then

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -61,7 +61,7 @@ jobs:
       CLUSTER_NAME: k8s-cancentral-01-covid-aks
       CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
       LOCAL_REPO: localhost:5000
-      TRIVY_VERSION: "v0.56.2"
+      TRIVY_VERSION: "v0.57.0"
       TRIVY_DATABASES: '"ghcr.io/aquasecurity/trivy-db:2","public.ecr.aws/aquasecurity/trivy-db"'
       TRIVY_JAVA_DATABASES: '"ghcr.io/aquasecurity/trivy-java-db:1","public.ecr.aws/aquasecurity/trivy-java-db"'
       TRIVY_MAX_RETRIES: 10

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -182,12 +182,14 @@ jobs:
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
         
+        set +e
+
         for ((i=0; i<${{ env.TRIVY_MAX_RETRIES }}; i++)); do
           echo "Attempt $((i + 1)) of ${{ env.TRIVY_MAX_RETRIES }}..."
 
           trivy image \
             ${{ steps.build-image.outputs.full_image_name }} \
-            --exit-code 10 --timeout=20m --scanners vuln --severity CRITICAL || true
+            --exit-code 10 --timeout=20m --scanners vuln --severity CRITICAL
           EXIT_CODE=$?
 
           if [[ $EXIT_CODE -eq 0 ]]; then

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -198,7 +198,7 @@ jobs:
           elif [[ $EXIT_CODE -eq 10 ]]; then
             echo "Trivy scan completed successfully. Some vulnerabilities were found."
             exit 10
-          elif [[ $i -lt $(( env.TRIVY_MAX_RETRIES - 1 )) ]]; then
+          elif [[ $i -lt $(( ${{ env.TRIVY_MAX_RETRIES }} - 1))  ]]; then
             echo "Encountered unexpected error. Retrying in ${{ env.TRIVY_RETRY_DELAY }} seconds..."
             sleep ${{ env.TRIVY_RETRY_DELAY }}
           else

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -189,29 +189,21 @@ jobs:
             --db-repository ${{ env.TRIVY_DATABASES }} \
             --java-db-repository ${{ env.TRIVY_JAVA_DATABASES }} \
             ${{ steps.build-image.outputs.full_image_name }} \
-            --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
+            --exit-code 10 --timeout=20m --scanners vuln --severity CRITICAL
           EXIT_CODE=$?
 
-          echo "Scan completed with exit code $EXIT_CODE" 
-          echo "$OUTPUT" 
-
-          # Check for TOOMANYREQUESTS error in the output
           if [[ $EXIT_CODE -eq 0 ]]; then
             echo "Trivy scan completed successfully."
-            echo "$OUTPUT"
-            break
-          elif echo "$OUTPUT" | grep -q "TOOMANYREQUESTS"; then
-            if [[ $i -lt ${{ env.TRIVY_MAX_RETRIES }} ]]; then
-              echo "Encountered TOOMANYREQUESTS error. Retrying in ${{ env.TRIVY_RETRY_DELAY }} seconds..."
-              sleep ${{ env.TRIVY_RETRY_DELAY }}
-            else
-              echo "TOOMANYREQUESTS error encountered after ${{ env.TRIVY_MAX_RETRIES }} attempts. Exiting."
-              exit 1
-            fi
+            exit 0
+          elif [[ $EXIT_CODE -eq 10 ]]; then
+            echo "Trivy scan completed successfully. Some vulnerabilities were found."
+            exit 10
+          elif [[ $i -lt ${{ env.TRIVY_MAX_RETRIES }} ]]; then
+            echo "Encountered unexpected error. Retrying in ${{ env.TRIVY_RETRY_DELAY }} seconds..."
+            sleep ${{ env.TRIVY_RETRY_DELAY }}
           else
-            echo "Trivy scan failed with a different error:"
-            echo "$OUTPUT"
-            exit $EXIT_CODE
+            echo "Unexpected error persists after ${{ env.TRIVY_MAX_RETRIES }} attempts. Exiting."
+            exit 1
           fi
         done
 

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -188,6 +188,8 @@ jobs:
           echo "Attempt $((i + 1)) of ${{ env.TRIVY_MAX_RETRIES }}..."
 
           trivy image \
+            --db-repository ${{ env.TRIVY_DATABASES }} \
+            --java-db-repository ${{ env.TRIVY_JAVA_DATABASES }} \
             ${{ steps.build-image.outputs.full_image_name }} \
             --exit-code 10 --timeout=20m --scanners vuln --severity CRITICAL
           EXIT_CODE=$?

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -64,7 +64,7 @@ jobs:
       TRIVY_VERSION: "v0.57.0"
       TRIVY_DATABASES: '"ghcr.io/aquasecurity/trivy-db:2","public.ecr.aws/aquasecurity/trivy-db"'
       TRIVY_JAVA_DATABASES: '"ghcr.io/aquasecurity/trivy-java-db:1","public.ecr.aws/aquasecurity/trivy-java-db"'
-      TRIVY_MAX_RETRIES: 10
+      TRIVY_MAX_RETRIES: 5
       TRIVY_RETRY_DELAY: 20
       HADOLINT_VERSION: "2.12.0"
       ACTIONS_RUNNER_DEBUG: true

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -186,8 +186,6 @@ jobs:
           echo "Attempt $((i + 1)) of ${{ env.TRIVY_MAX_RETRIES }}..."
 
           trivy image \
-            --db-repository ${{ env.TRIVY_DATABASES }} \
-            --java-db-repository ${{ env.TRIVY_JAVA_DATABASES }} \
             ${{ steps.build-image.outputs.full_image_name }} \
             --exit-code 10 --timeout=20m --scanners vuln --severity CRITICAL
           EXIT_CODE=$?

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -64,6 +64,8 @@ jobs:
       TRIVY_VERSION: "v0.56.2"
       TRIVY_DATABASES: '"ghcr.io/aquasecurity/trivy-db:2","public.ecr.aws/aquasecurity/trivy-db"'
       TRIVY_JAVA_DATABASES: '"ghcr.io/aquasecurity/trivy-java-db:1","public.ecr.aws/aquasecurity/trivy-java-db"'
+      TRIVY_MAX_RETRIES: 10
+      TRIVY_RETRY_DELAY: 20
       HADOLINT_VERSION: "2.12.0"
       ACTIONS_RUNNER_DEBUG: true
 
@@ -179,11 +181,35 @@ jobs:
       run: |
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image \
-          --db-repository ${{ env.TRIVY_DATABASES }} \
-          --java-db-repository ${{ env.TRIVY_JAVA_DATABASES }} \
-          ${{ steps.build-image.outputs.full_image_name }} \
-          --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
+        for ((i=0; i<${{ env.TRIVY_MAX_RETRIES }}; i++)); do
+          echo "Attempt $((i + 1)) of ${{ env.TRIVY_MAX_RETRIES }}..."
+          
+          # Run Trivy and capture output
+          trivy image \
+            --db-repository ${{ env.TRIVY_DATABASES }} \
+            --java-db-repository ${{ env.TRIVY_JAVA_DATABASES }} \
+            ${{ steps.build-image.outputs.full_image_name }} \
+            --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
+          EXIT_CODE=$?
+
+          # Check for TOOMANYREQUESTS error in the output
+          if [[ $EXIT_CODE -eq 0 ]]; then
+            echo "Trivy scan completed successfully."
+            break
+          elif echo "$OUTPUT" | grep -q "TOOMANYREQUESTS"; then
+            if [[ $i -lt ${{ env.TRIVY_MAX_RETRIES }} ]]; then
+              echo "Encountered TOOMANYREQUESTS error. Retrying in ${{ env.TRIVY_RETRY_DELAY }} seconds..."
+              sleep ${{ env.TRIVY_RETRY_DELAY }}
+            else
+              echo "TOOMANYREQUESTS error encountered after ${{ env.TRIVY_MAX_RETRIES }} attempts. Exiting."
+              exit 1
+            fi
+          else
+            echo "Trivy scan failed with a different error:"
+            echo "$OUTPUT"
+            exit $EXIT_CODE
+          fi
+        done
 
     # Push image to ACR
     # Pushes if this is a push to master or an update to a PR that has auto-deploy label

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -181,10 +181,10 @@ jobs:
       run: |
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
+        
         for ((i=0; i<${{ env.TRIVY_MAX_RETRIES }}; i++)); do
           echo "Attempt $((i + 1)) of ${{ env.TRIVY_MAX_RETRIES }}..."
-          
-          # Run Trivy and capture output
+
           trivy image \
             --db-repository ${{ env.TRIVY_DATABASES }} \
             --java-db-repository ${{ env.TRIVY_JAVA_DATABASES }} \
@@ -198,7 +198,7 @@ jobs:
           elif [[ $EXIT_CODE -eq 10 ]]; then
             echo "Trivy scan completed successfully. Some vulnerabilities were found."
             exit 10
-          elif [[ $i -lt ${{ env.TRIVY_MAX_RETRIES }} ]]; then
+          elif [[ $i -lt $(( env.TRIVY_MAX_RETRIES - 1 )) ]]; then
             echo "Encountered unexpected error. Retrying in ${{ env.TRIVY_RETRY_DELAY }} seconds..."
             sleep ${{ env.TRIVY_RETRY_DELAY }}
           else

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -192,9 +192,13 @@ jobs:
             --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
           EXIT_CODE=$?
 
+          echo "Scan completed with exit code $EXIT_CODE" 
+          echo "$OUTPUT" 
+
           # Check for TOOMANYREQUESTS error in the output
           if [[ $EXIT_CODE -eq 0 ]]; then
             echo "Trivy scan completed successfully."
+            echo "$OUTPUT"
             break
           elif echo "$OUTPUT" | grep -q "TOOMANYREQUESTS"; then
             if [[ $i -lt ${{ env.TRIVY_MAX_RETRIES }} ]]; then


### PR DESCRIPTION
Changed trivy error code to 10. This means if vulnerabilities are found, it will error with exit code 10. 
This lets us retry any scan that had an error that was not finding vulnerabilities, since general errors are code 1. 

Will retry up to 5 times. 

The code is written like this as trivy doesn't actually write anything to an output variable on return, so there isn't any way to look for the `TOOMANYREQUESTS` error specifically. 

Closes https://github.com/StatCan/aaw/issues/1981