### PR TITLE
Add lmodern so Quarto can produce PDF documents.

### DIFF
--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -15,7 +15,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 # - Going to try now only installing lmodern without tinytex and see if that is sufficient.
-RUN apt-get install lmodern -y \
+RUN apt-get update && sudo apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -15,7 +15,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 RUN quarto install tinytex \
-    && apt-get install lmodern -y \
+    && apt-get install fonts-lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -12,7 +12,6 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
 # Install LaTeX related things required by Quarto
-
 RUN quarto install tinytex
 
 RUN groupadd -g 1002 sasstaff && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -12,7 +12,11 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
 # Install LaTeX related things required by Quarto
-RUN quarto install tinytex
+# on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
+# but on The Zone I need to install lmodern explicitly
+RUN quarto install tinytex \
+    && apt-get install lmodern -y \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -11,6 +11,10 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
+# Install LaTeX related things required by Quarto
+
+RUN quarto install tinytex
+
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \
     echo "jovyan:jovyan" | chpasswd

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -9,11 +9,10 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     echo "${QUARTO_SHA} /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | sha256sum -c - && \
     tar -xzvf /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz -C /tmp/ && \
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
-    ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
-
-# Install lmodern, required by LaTeX so Quarto can produce PDFs
-RUN apt-get update && sudo apt-get install lmodern -y \
-    && rm -rf /var/lib/apt/lists/*
+    ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto && \
+    # Install lmodern, required by LaTeX so Quarto can produce PDFs
+    apt-get update && sudo apt-get install lmodern -y && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -11,10 +11,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
-# Install LaTeX related things required by Quarto
-# on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
-# but on The Zone I need to install lmodern explicitly
-# - Going to try now only installing lmodern without tinytex and see if that is sufficient.
+# Install lmodern, required by LaTeX so Quarto can produce PDFs
 RUN apt-get update && sudo apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -14,8 +14,8 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # Install LaTeX related things required by Quarto
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
-RUN quarto install tinytex \
-    && apt-get install fonts-lmodern -y \
+# - Going to try now only installing lmodern without tinytex and see if that is sufficient.
+RUN apt-get install fonts-lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -15,7 +15,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 # - Going to try now only installing lmodern without tinytex and see if that is sufficient.
-RUN apt-get install fonts-lmodern -y \
+RUN apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -413,7 +413,6 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
 # Install LaTeX related things required by Quarto
-
 RUN quarto install tinytex
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -410,11 +410,10 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     echo "${QUARTO_SHA} /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | sha256sum -c - && \
     tar -xzvf /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz -C /tmp/ && \
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
-    ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
-
-# Install lmodern, required by LaTeX so Quarto can produce PDFs
-RUN apt-get update && sudo apt-get install lmodern -y \
-    && rm -rf /var/lib/apt/lists/*
+    ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto && \
+    # Install lmodern, required by LaTeX so Quarto can produce PDFs
+    apt-get update && sudo apt-get install lmodern -y && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -412,10 +412,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
-# Install LaTeX related things required by Quarto
-# on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
-# but on The Zone I need to install lmodern explicitly
-# - Going to try now only installing lmodern without tinytex and see if that is sufficient.
+# Install lmodern, required by LaTeX so Quarto can produce PDFs
 RUN apt-get update && sudo apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -416,7 +416,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 RUN quarto install tinytex \
-    && apt-get install lmodern -y \
+    && apt-get install fonts-lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -416,7 +416,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 # - Going to try now only installing lmodern without tinytex and see if that is sufficient.
-RUN apt-get install fonts-lmodern -y \
+RUN apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -413,7 +413,11 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
 # Install LaTeX related things required by Quarto
-RUN quarto install tinytex
+# on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
+# but on The Zone I need to install lmodern explicitly
+RUN quarto install tinytex \
+    && apt-get install lmodern -y \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -415,8 +415,8 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # Install LaTeX related things required by Quarto
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
-RUN quarto install tinytex \
-    && apt-get install fonts-lmodern -y \
+# - Going to try now only installing lmodern without tinytex and see if that is sufficient.
+RUN apt-get install fonts-lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -412,6 +412,10 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
+# Install LaTeX related things required by Quarto
+
+RUN quarto install tinytex
+
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \
     echo "jovyan:jovyan" | chpasswd

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -416,7 +416,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 # - Going to try now only installing lmodern without tinytex and see if that is sufficient.
-RUN apt-get install lmodern -y \
+RUN apt-get update && sudo apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -435,7 +435,11 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
 # Install LaTeX related things required by Quarto
-RUN quarto install tinytex
+# on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
+# but on The Zone I need to install lmodern explicitly
+RUN quarto install tinytex \
+    && apt-get install lmodern -y \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -435,7 +435,6 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
 # Install LaTeX related things required by Quarto
-
 RUN quarto install tinytex
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -434,6 +434,10 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
+# Install LaTeX related things required by Quarto
+
+RUN quarto install tinytex
+
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \
     echo "jovyan:jovyan" | chpasswd

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -437,8 +437,8 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # Install LaTeX related things required by Quarto
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
-RUN quarto install tinytex \
-    && apt-get install fonts-lmodern -y \
+# - Going to try now only installing lmodern without tinytex and see if that is sufficient.
+RUN apt-get install fonts-lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -438,7 +438,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 # - Going to try now only installing lmodern without tinytex and see if that is sufficient.
-RUN apt-get install lmodern -y \
+RUN apt-get update && sudo apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -438,7 +438,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 RUN quarto install tinytex \
-    && apt-get install lmodern -y \
+    && apt-get install fonts-lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -438,7 +438,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 # - Going to try now only installing lmodern without tinytex and see if that is sufficient.
-RUN apt-get install fonts-lmodern -y \
+RUN apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -434,10 +434,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
-# Install LaTeX related things required by Quarto
-# on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
-# but on The Zone I need to install lmodern explicitly
-# - Going to try now only installing lmodern without tinytex and see if that is sufficient.
+# Install lmodern, required by LaTeX so Quarto can produce PDFs
 RUN apt-get update && sudo apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -432,11 +432,10 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     echo "${QUARTO_SHA} /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | sha256sum -c - && \
     tar -xzvf /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz -C /tmp/ && \
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
-    ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
-
-# Install lmodern, required by LaTeX so Quarto can produce PDFs
-RUN apt-get update && sudo apt-get install lmodern -y \
-    && rm -rf /var/lib/apt/lists/*
+    ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto && \
+    # Install lmodern, required by LaTeX so Quarto can produce PDFs
+    apt-get update && sudo apt-get install lmodern -y && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -545,7 +545,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 # - Going to try now only installing lmodern without tinytex and see if that is sufficient.
-RUN apt-get install lmodern -y \
+RUN apt-get update && sudo apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -544,8 +544,8 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # Install LaTeX related things required by Quarto
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
-RUN quarto install tinytex \
-    && apt-get install fonts-lmodern -y \
+# - Going to try now only installing lmodern without tinytex and see if that is sufficient.
+RUN apt-get install fonts-lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -542,7 +542,11 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
 # Install LaTeX related things required by Quarto
-RUN quarto install tinytex
+# on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
+# but on The Zone I need to install lmodern explicitly
+RUN quarto install tinytex \
+    && apt-get install lmodern -y \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -541,10 +541,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
-# Install LaTeX related things required by Quarto
-# on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
-# but on The Zone I need to install lmodern explicitly
-# - Going to try now only installing lmodern without tinytex and see if that is sufficient.
+# Install lmodern, required by LaTeX so Quarto can produce PDFs
 RUN apt-get update && sudo apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -545,7 +545,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 # - Going to try now only installing lmodern without tinytex and see if that is sufficient.
-RUN apt-get install fonts-lmodern -y \
+RUN apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -542,7 +542,6 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
 # Install LaTeX related things required by Quarto
-
 RUN quarto install tinytex
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -545,7 +545,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 RUN quarto install tinytex \
-    && apt-get install lmodern -y \
+    && apt-get install fonts-lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -541,6 +541,10 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
+# Install LaTeX related things required by Quarto
+
+RUN quarto install tinytex
+
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \
     echo "jovyan:jovyan" | chpasswd

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -539,11 +539,10 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     echo "${QUARTO_SHA} /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | sha256sum -c - && \
     tar -xzvf /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz -C /tmp/ && \
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
-    ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
-
-# Install lmodern, required by LaTeX so Quarto can produce PDFs
-RUN apt-get update && sudo apt-get install lmodern -y \
-    && rm -rf /var/lib/apt/lists/*
+    ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto && \
+    # Install lmodern, required by LaTeX so Quarto can produce PDFs
+    apt-get update && sudo apt-get install lmodern -y && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -417,7 +417,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 RUN quarto install tinytex \
-    && apt-get install lmodern -y \
+    && apt-get install fonts-lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -413,6 +413,10 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
+# Install LaTeX related things required by Quarto
+
+RUN quarto install tinytex
+
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \
     echo "jovyan:jovyan" | chpasswd

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -416,8 +416,8 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # Install LaTeX related things required by Quarto
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
-RUN quarto install tinytex \
-    && apt-get install fonts-lmodern -y \
+# - Going to try now only installing lmodern without tinytex and see if that is sufficient.
+RUN apt-get install fonts-lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -413,10 +413,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
-# Install LaTeX related things required by Quarto
-# on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
-# but on The Zone I need to install lmodern explicitly
-# - Going to try now only installing lmodern without tinytex and see if that is sufficient.
+# Install lmodern, required by LaTeX so Quarto can produce PDFs
 RUN apt-get update && sudo apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -414,7 +414,11 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
 # Install LaTeX related things required by Quarto
-RUN quarto install tinytex
+# on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
+# but on The Zone I need to install lmodern explicitly
+RUN quarto install tinytex \
+    && apt-get install lmodern -y \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -414,7 +414,6 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
 
 # Install LaTeX related things required by Quarto
-
 RUN quarto install tinytex
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -417,7 +417,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 # - Going to try now only installing lmodern without tinytex and see if that is sufficient.
-RUN apt-get install fonts-lmodern -y \
+RUN apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -411,11 +411,10 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
     echo "${QUARTO_SHA} /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | sha256sum -c - && \
     tar -xzvf /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz -C /tmp/ && \
     chmod +x /tmp/quarto-${QUARTO_VERSION} && \
-    ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto
-
-# Install lmodern, required by LaTeX so Quarto can produce PDFs
-RUN apt-get update && sudo apt-get install lmodern -y \
-    && rm -rf /var/lib/apt/lists/*
+    ln -s /tmp/quarto-${QUARTO_VERSION}/bin/quarto /usr/bin/quarto && \
+    # Install lmodern, required by LaTeX so Quarto can produce PDFs
+    apt-get update && sudo apt-get install lmodern -y && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \
     usermod -a -G sasstaff jovyan && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -417,7 +417,7 @@ RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz &&
 # on my VM I don't need to actually install lmodern, quarto install tinytex is sufficient,
 # but on The Zone I need to install lmodern explicitly
 # - Going to try now only installing lmodern without tinytex and see if that is sufficient.
-RUN apt-get install lmodern -y \
+RUN apt-get update && sudo apt-get install lmodern -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1002 sasstaff && \


### PR DESCRIPTION
Add `lmodern` so Quarto can produce PDF documents.

- JIRA: https://jirab.statcan.ca/browse/BTIS-592

The issue was resolved by installing the `lmodern` package using `apt-get`. However, it was necessary to run `apt-get update` beforehand, as the SAS image was unable to locate the `lmodern` package without updating the package lists.