### PR TITLE
feat: add ktutil and a helper script to our images

### DIFF
--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
+      # installs necessary tool for kerberos authentication setup
+      'krb5-user' \
       # these are required by some r packages, adding these here so they get
       # installed into all images.
       'libfreetype6-dev' \
@@ -96,3 +98,5 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && echo "${GIT_CRED_MANAGER_SHA}  ./gcm.deb" | sha256sum -c - \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
+
+COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -99,4 +99,6 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
+# add script for kerberos keytab creation
 COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
+RUN chmod +x /usr/local/bin/ktutil-keytab

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -99,4 +99,4 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
-COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
+COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab

--- a/output/docker-stacks-datascience-notebook/ktutil-keytab.sh
+++ b/output/docker-stacks-datascience-notebook/ktutil-keytab.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# creates the kerberos directory if not exist
+mkdir -p ~/krb5
+cd ~/krb5
+
+# gets the user's username (legacy AD)
+read -p "Username(ex. marcoma):" user_name
+
+user_name="${user_name}@STATCAN.CA"
+# gets the user's password
+read -sp "Password for ${user_name}:" user_pass
+
+# deletes the password prompt for cleaner output
+echo -en "\r\e[K"
+
+{
+# adds entry for user, and requests password
+echo "addent -password -p ${user_name} -k 1 -e RC4-HMAC";
+# give password entered by user to ktutil
+echo "$user_pass"
+# creates keytab file
+echo "wkt client.keytab";
+} | ktutil
+
+# get the current namespace
+NS=$(kubectl get sa -o=jsonpath='{.items[0]..metadata.namespace}')
+
+# generate the secret
+kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab -o yaml --dry-run=client > ktutil_keytab.yaml
+
+# apply the secret
+kubectl apply -f ./ktutil_keytab.yaml

--- a/output/docker-stacks-datascience-notebook/ktutil-keytab.sh
+++ b/output/docker-stacks-datascience-notebook/ktutil-keytab.sh
@@ -30,3 +30,17 @@ kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab
 
 # apply the secret
 kubectl apply -f ./ktutil_keytab.yaml
+
+
+#get the notebook name
+nb_name=${NB_PREFIX##*/}
+
+# Prompt user for notebook restart
+while true; do
+    read -p "In order to update the kerberos authentication, the notebook server needs to be restarted. Would you like to restart your notebook server?[Y/n]: " yn
+    case $yn in
+        [Yy]* ) echo "Your notebook server will now restart"; kubectl rollout restart statefulset $nb_name -n $NB_NAMESPACE; break;;
+        [Nn]* ) echo "Your notebook server will not be restarted"; exit;;
+        * ) echo "Only yes or no is an expected answer";;
+    esac
+done

--- a/output/docker-stacks-datascience-notebook/ktutil-keytab.sh
+++ b/output/docker-stacks-datascience-notebook/ktutil-keytab.sh
@@ -3,6 +3,11 @@
 mkdir -p ~/krb5
 cd ~/krb5
 
+#clean up from previous run(or else it appends to the file instead of replacing it)
+if [ -f ./client.keytab ]; then
+    rm ./client.keytab
+fi
+
 # gets the user's username (legacy AD)
 read -p "Username(ex. marcoma):" user_name
 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -78,6 +78,8 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
+      # installs necessary tool for kerberos authentication setup
+      'krb5-user' \
       # these are required by some r packages, adding these here so they get
       # installed into all images.
       'libfreetype6-dev' \
@@ -155,6 +157,8 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && echo "${GIT_CRED_MANAGER_SHA}  ./gcm.deb" | sha256sum -c - \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
+
+COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -158,7 +158,9 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
+# add script for kerberos keytab creation
 COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
+RUN chmod +x /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -158,7 +158,7 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
-COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
+COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-cpu/ktutil-keytab.sh
+++ b/output/jupyterlab-cpu/ktutil-keytab.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# creates the kerberos directory if not exist
+mkdir -p ~/krb5
+cd ~/krb5
+
+# gets the user's username (legacy AD)
+read -p "Username(ex. marcoma):" user_name
+
+user_name="${user_name}@STATCAN.CA"
+# gets the user's password
+read -sp "Password for ${user_name}:" user_pass
+
+# deletes the password prompt for cleaner output
+echo -en "\r\e[K"
+
+{
+# adds entry for user, and requests password
+echo "addent -password -p ${user_name} -k 1 -e RC4-HMAC";
+# give password entered by user to ktutil
+echo "$user_pass"
+# creates keytab file
+echo "wkt client.keytab";
+} | ktutil
+
+# get the current namespace
+NS=$(kubectl get sa -o=jsonpath='{.items[0]..metadata.namespace}')
+
+# generate the secret
+kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab -o yaml --dry-run=client > ktutil_keytab.yaml
+
+# apply the secret
+kubectl apply -f ./ktutil_keytab.yaml

--- a/output/jupyterlab-cpu/ktutil-keytab.sh
+++ b/output/jupyterlab-cpu/ktutil-keytab.sh
@@ -30,3 +30,17 @@ kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab
 
 # apply the secret
 kubectl apply -f ./ktutil_keytab.yaml
+
+
+#get the notebook name
+nb_name=${NB_PREFIX##*/}
+
+# Prompt user for notebook restart
+while true; do
+    read -p "In order to update the kerberos authentication, the notebook server needs to be restarted. Would you like to restart your notebook server?[Y/n]: " yn
+    case $yn in
+        [Yy]* ) echo "Your notebook server will now restart"; kubectl rollout restart statefulset $nb_name -n $NB_NAMESPACE; break;;
+        [Nn]* ) echo "Your notebook server will not be restarted"; exit;;
+        * ) echo "Only yes or no is an expected answer";;
+    esac
+done

--- a/output/jupyterlab-cpu/ktutil-keytab.sh
+++ b/output/jupyterlab-cpu/ktutil-keytab.sh
@@ -3,6 +3,11 @@
 mkdir -p ~/krb5
 cd ~/krb5
 
+#clean up from previous run(or else it appends to the file instead of replacing it)
+if [ -f ./client.keytab ]; then
+    rm ./client.keytab
+fi
+
 # gets the user's username (legacy AD)
 read -p "Username(ex. marcoma):" user_name
 

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -100,6 +100,8 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
+      # installs necessary tool for kerberos authentication setup
+      'krb5-user' \
       # these are required by some r packages, adding these here so they get
       # installed into all images.
       'libfreetype6-dev' \
@@ -177,6 +179,8 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && echo "${GIT_CRED_MANAGER_SHA}  ./gcm.deb" | sha256sum -c - \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
+
+COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -180,7 +180,7 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
-COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
+COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -180,7 +180,9 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
+# add script for kerberos keytab creation
 COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
+RUN chmod +x /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-pytorch/ktutil-keytab.sh
+++ b/output/jupyterlab-pytorch/ktutil-keytab.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# creates the kerberos directory if not exist
+mkdir -p ~/krb5
+cd ~/krb5
+
+# gets the user's username (legacy AD)
+read -p "Username(ex. marcoma):" user_name
+
+user_name="${user_name}@STATCAN.CA"
+# gets the user's password
+read -sp "Password for ${user_name}:" user_pass
+
+# deletes the password prompt for cleaner output
+echo -en "\r\e[K"
+
+{
+# adds entry for user, and requests password
+echo "addent -password -p ${user_name} -k 1 -e RC4-HMAC";
+# give password entered by user to ktutil
+echo "$user_pass"
+# creates keytab file
+echo "wkt client.keytab";
+} | ktutil
+
+# get the current namespace
+NS=$(kubectl get sa -o=jsonpath='{.items[0]..metadata.namespace}')
+
+# generate the secret
+kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab -o yaml --dry-run=client > ktutil_keytab.yaml
+
+# apply the secret
+kubectl apply -f ./ktutil_keytab.yaml

--- a/output/jupyterlab-pytorch/ktutil-keytab.sh
+++ b/output/jupyterlab-pytorch/ktutil-keytab.sh
@@ -30,3 +30,17 @@ kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab
 
 # apply the secret
 kubectl apply -f ./ktutil_keytab.yaml
+
+
+#get the notebook name
+nb_name=${NB_PREFIX##*/}
+
+# Prompt user for notebook restart
+while true; do
+    read -p "In order to update the kerberos authentication, the notebook server needs to be restarted. Would you like to restart your notebook server?[Y/n]: " yn
+    case $yn in
+        [Yy]* ) echo "Your notebook server will now restart"; kubectl rollout restart statefulset $nb_name -n $NB_NAMESPACE; break;;
+        [Nn]* ) echo "Your notebook server will not be restarted"; exit;;
+        * ) echo "Only yes or no is an expected answer";;
+    esac
+done

--- a/output/jupyterlab-pytorch/ktutil-keytab.sh
+++ b/output/jupyterlab-pytorch/ktutil-keytab.sh
@@ -3,6 +3,11 @@
 mkdir -p ~/krb5
 cd ~/krb5
 
+#clean up from previous run(or else it appends to the file instead of replacing it)
+if [ -f ./client.keytab ]; then
+    rm ./client.keytab
+fi
+
 # gets the user's username (legacy AD)
 read -p "Username(ex. marcoma):" user_name
 

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -287,7 +287,9 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
+# add script for kerberos keytab creation
 COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
+RUN chmod +x /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -287,7 +287,7 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
-COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
+COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -207,6 +207,8 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
+      # installs necessary tool for kerberos authentication setup
+      'krb5-user' \
       # these are required by some r packages, adding these here so they get
       # installed into all images.
       'libfreetype6-dev' \
@@ -284,6 +286,8 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && echo "${GIT_CRED_MANAGER_SHA}  ./gcm.deb" | sha256sum -c - \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
+
+COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/jupyterlab-tensorflow/ktutil-keytab.sh
+++ b/output/jupyterlab-tensorflow/ktutil-keytab.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# creates the kerberos directory if not exist
+mkdir -p ~/krb5
+cd ~/krb5
+
+# gets the user's username (legacy AD)
+read -p "Username(ex. marcoma):" user_name
+
+user_name="${user_name}@STATCAN.CA"
+# gets the user's password
+read -sp "Password for ${user_name}:" user_pass
+
+# deletes the password prompt for cleaner output
+echo -en "\r\e[K"
+
+{
+# adds entry for user, and requests password
+echo "addent -password -p ${user_name} -k 1 -e RC4-HMAC";
+# give password entered by user to ktutil
+echo "$user_pass"
+# creates keytab file
+echo "wkt client.keytab";
+} | ktutil
+
+# get the current namespace
+NS=$(kubectl get sa -o=jsonpath='{.items[0]..metadata.namespace}')
+
+# generate the secret
+kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab -o yaml --dry-run=client > ktutil_keytab.yaml
+
+# apply the secret
+kubectl apply -f ./ktutil_keytab.yaml

--- a/output/jupyterlab-tensorflow/ktutil-keytab.sh
+++ b/output/jupyterlab-tensorflow/ktutil-keytab.sh
@@ -30,3 +30,17 @@ kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab
 
 # apply the secret
 kubectl apply -f ./ktutil_keytab.yaml
+
+
+#get the notebook name
+nb_name=${NB_PREFIX##*/}
+
+# Prompt user for notebook restart
+while true; do
+    read -p "In order to update the kerberos authentication, the notebook server needs to be restarted. Would you like to restart your notebook server?[Y/n]: " yn
+    case $yn in
+        [Yy]* ) echo "Your notebook server will now restart"; kubectl rollout restart statefulset $nb_name -n $NB_NAMESPACE; break;;
+        [Nn]* ) echo "Your notebook server will not be restarted"; exit;;
+        * ) echo "Only yes or no is an expected answer";;
+    esac
+done

--- a/output/jupyterlab-tensorflow/ktutil-keytab.sh
+++ b/output/jupyterlab-tensorflow/ktutil-keytab.sh
@@ -3,6 +3,11 @@
 mkdir -p ~/krb5
 cd ~/krb5
 
+#clean up from previous run(or else it appends to the file instead of replacing it)
+if [ -f ./client.keytab ]; then
+    rm ./client.keytab
+fi
+
 # gets the user's username (legacy AD)
 read -p "Username(ex. marcoma):" user_name
 

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -230,7 +230,9 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
+# add script for kerberos keytab creation
 COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
+RUN chmod +x /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/6_remote-desktop.Dockerfile

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -230,7 +230,7 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
-COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
+COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/6_remote-desktop.Dockerfile

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -150,6 +150,8 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
+      # installs necessary tool for kerberos authentication setup
+      'krb5-user' \
       # these are required by some r packages, adding these here so they get
       # installed into all images.
       'libfreetype6-dev' \
@@ -227,6 +229,8 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && echo "${GIT_CRED_MANAGER_SHA}  ./gcm.deb" | sha256sum -c - \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
+
+COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/6_remote-desktop.Dockerfile

--- a/output/remote-desktop/ktutil-keytab.sh
+++ b/output/remote-desktop/ktutil-keytab.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# creates the kerberos directory if not exist
+mkdir -p ~/krb5
+cd ~/krb5
+
+# gets the user's username (legacy AD)
+read -p "Username(ex. marcoma):" user_name
+
+user_name="${user_name}@STATCAN.CA"
+# gets the user's password
+read -sp "Password for ${user_name}:" user_pass
+
+# deletes the password prompt for cleaner output
+echo -en "\r\e[K"
+
+{
+# adds entry for user, and requests password
+echo "addent -password -p ${user_name} -k 1 -e RC4-HMAC";
+# give password entered by user to ktutil
+echo "$user_pass"
+# creates keytab file
+echo "wkt client.keytab";
+} | ktutil
+
+# get the current namespace
+NS=$(kubectl get sa -o=jsonpath='{.items[0]..metadata.namespace}')
+
+# generate the secret
+kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab -o yaml --dry-run=client > ktutil_keytab.yaml
+
+# apply the secret
+kubectl apply -f ./ktutil_keytab.yaml

--- a/output/remote-desktop/ktutil-keytab.sh
+++ b/output/remote-desktop/ktutil-keytab.sh
@@ -30,3 +30,17 @@ kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab
 
 # apply the secret
 kubectl apply -f ./ktutil_keytab.yaml
+
+
+#get the notebook name
+nb_name=${NB_PREFIX##*/}
+
+# Prompt user for notebook restart
+while true; do
+    read -p "In order to update the kerberos authentication, the notebook server needs to be restarted. Would you like to restart your notebook server?[Y/n]: " yn
+    case $yn in
+        [Yy]* ) echo "Your notebook server will now restart"; kubectl rollout restart statefulset $nb_name -n $NB_NAMESPACE; break;;
+        [Nn]* ) echo "Your notebook server will not be restarted"; exit;;
+        * ) echo "Only yes or no is an expected answer";;
+    esac
+done

--- a/output/remote-desktop/ktutil-keytab.sh
+++ b/output/remote-desktop/ktutil-keytab.sh
@@ -3,6 +3,11 @@
 mkdir -p ~/krb5
 cd ~/krb5
 
+#clean up from previous run(or else it appends to the file instead of replacing it)
+if [ -f ./client.keytab ]; then
+    rm ./client.keytab
+fi
+
 # gets the user's username (legacy AD)
 read -p "Username(ex. marcoma):" user_name
 

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -78,6 +78,8 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
+      # installs necessary tool for kerberos authentication setup
+      'krb5-user' \
       # these are required by some r packages, adding these here so they get
       # installed into all images.
       'libfreetype6-dev' \
@@ -155,6 +157,8 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && echo "${GIT_CRED_MANAGER_SHA}  ./gcm.deb" | sha256sum -c - \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
+
+COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -158,7 +158,9 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
+# add script for kerberos keytab creation
 COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
+RUN chmod +x /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -158,7 +158,7 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
-COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
+COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/rstudio/ktutil-keytab.sh
+++ b/output/rstudio/ktutil-keytab.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# creates the kerberos directory if not exist
+mkdir -p ~/krb5
+cd ~/krb5
+
+# gets the user's username (legacy AD)
+read -p "Username(ex. marcoma):" user_name
+
+user_name="${user_name}@STATCAN.CA"
+# gets the user's password
+read -sp "Password for ${user_name}:" user_pass
+
+# deletes the password prompt for cleaner output
+echo -en "\r\e[K"
+
+{
+# adds entry for user, and requests password
+echo "addent -password -p ${user_name} -k 1 -e RC4-HMAC";
+# give password entered by user to ktutil
+echo "$user_pass"
+# creates keytab file
+echo "wkt client.keytab";
+} | ktutil
+
+# get the current namespace
+NS=$(kubectl get sa -o=jsonpath='{.items[0]..metadata.namespace}')
+
+# generate the secret
+kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab -o yaml --dry-run=client > ktutil_keytab.yaml
+
+# apply the secret
+kubectl apply -f ./ktutil_keytab.yaml

--- a/output/rstudio/ktutil-keytab.sh
+++ b/output/rstudio/ktutil-keytab.sh
@@ -30,3 +30,17 @@ kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab
 
 # apply the secret
 kubectl apply -f ./ktutil_keytab.yaml
+
+
+#get the notebook name
+nb_name=${NB_PREFIX##*/}
+
+# Prompt user for notebook restart
+while true; do
+    read -p "In order to update the kerberos authentication, the notebook server needs to be restarted. Would you like to restart your notebook server?[Y/n]: " yn
+    case $yn in
+        [Yy]* ) echo "Your notebook server will now restart"; kubectl rollout restart statefulset $nb_name -n $NB_NAMESPACE; break;;
+        [Nn]* ) echo "Your notebook server will not be restarted"; exit;;
+        * ) echo "Only yes or no is an expected answer";;
+    esac
+done

--- a/output/rstudio/ktutil-keytab.sh
+++ b/output/rstudio/ktutil-keytab.sh
@@ -3,6 +3,11 @@
 mkdir -p ~/krb5
 cd ~/krb5
 
+#clean up from previous run(or else it appends to the file instead of replacing it)
+if [ -f ./client.keytab ]; then
+    rm ./client.keytab
+fi
+
 # gets the user's username (legacy AD)
 read -p "Username(ex. marcoma):" user_name
 

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -78,6 +78,8 @@ RUN apt-get update && \
       'zip' \
       'zsh' \
       'dos2unix' \
+      # installs necessary tool for kerberos authentication setup
+      'krb5-user' \
       # these are required by some r packages, adding these here so they get
       # installed into all images.
       'libfreetype6-dev' \
@@ -155,6 +157,8 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && echo "${GIT_CRED_MANAGER_SHA}  ./gcm.deb" | sha256sum -c - \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
+
+COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -158,7 +158,9 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
+# add script for kerberos keytab creation
 COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
+RUN chmod +x /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -158,7 +158,7 @@ RUN wget -q "${GIT_CRED_MANAGER_URL}" -O ./gcm.deb \
   && dpkg -i ./gcm.deb \
   && rm ./gcm.deb
 
-COPY ktutil-keytab.sh /home/$NB_USER/.local/bin/ktutil-keytab
+COPY ktutil-keytab.sh /usr/local/bin/ktutil-keytab
 
 ###############################
 ###  docker-bits/5_DB-Drivers.Dockerfile

--- a/output/sas/ktutil-keytab.sh
+++ b/output/sas/ktutil-keytab.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# creates the kerberos directory if not exist
+mkdir -p ~/krb5
+cd ~/krb5
+
+# gets the user's username (legacy AD)
+read -p "Username(ex. marcoma):" user_name
+
+user_name="${user_name}@STATCAN.CA"
+# gets the user's password
+read -sp "Password for ${user_name}:" user_pass
+
+# deletes the password prompt for cleaner output
+echo -en "\r\e[K"
+
+{
+# adds entry for user, and requests password
+echo "addent -password -p ${user_name} -k 1 -e RC4-HMAC";
+# give password entered by user to ktutil
+echo "$user_pass"
+# creates keytab file
+echo "wkt client.keytab";
+} | ktutil
+
+# get the current namespace
+NS=$(kubectl get sa -o=jsonpath='{.items[0]..metadata.namespace}')
+
+# generate the secret
+kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab -o yaml --dry-run=client > ktutil_keytab.yaml
+
+# apply the secret
+kubectl apply -f ./ktutil_keytab.yaml

--- a/output/sas/ktutil-keytab.sh
+++ b/output/sas/ktutil-keytab.sh
@@ -30,3 +30,17 @@ kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab
 
 # apply the secret
 kubectl apply -f ./ktutil_keytab.yaml
+
+
+#get the notebook name
+nb_name=${NB_PREFIX##*/}
+
+# Prompt user for notebook restart
+while true; do
+    read -p "In order to update the kerberos authentication, the notebook server needs to be restarted. Would you like to restart your notebook server?[Y/n]: " yn
+    case $yn in
+        [Yy]* ) echo "Your notebook server will now restart"; kubectl rollout restart statefulset $nb_name -n $NB_NAMESPACE; break;;
+        [Nn]* ) echo "Your notebook server will not be restarted"; exit;;
+        * ) echo "Only yes or no is an expected answer";;
+    esac
+done

--- a/output/sas/ktutil-keytab.sh
+++ b/output/sas/ktutil-keytab.sh
@@ -3,6 +3,11 @@
 mkdir -p ~/krb5
 cd ~/krb5
 
+#clean up from previous run(or else it appends to the file instead of replacing it)
+if [ -f ./client.keytab ]; then
+    rm ./client.keytab
+fi
+
 # gets the user's username (legacy AD)
 read -p "Username(ex. marcoma):" user_name
 

--- a/resources/common/ktutil-keytab.sh
+++ b/resources/common/ktutil-keytab.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# creates the kerberos directory if not exist
+mkdir -p ~/krb5
+cd ~/krb5
+
+# gets the user's username (legacy AD)
+read -p "Username(ex. marcoma):" user_name
+
+user_name="${user_name}@STATCAN.CA"
+# gets the user's password
+read -sp "Password for ${user_name}:" user_pass
+
+# deletes the password prompt for cleaner output
+echo -en "\r\e[K"
+
+{
+# adds entry for user, and requests password
+echo "addent -password -p ${user_name} -k 1 -e RC4-HMAC";
+# give password entered by user to ktutil
+echo "$user_pass"
+# creates keytab file
+echo "wkt client.keytab";
+} | ktutil
+
+# get the current namespace
+NS=$(kubectl get sa -o=jsonpath='{.items[0]..metadata.namespace}')
+
+# generate the secret
+kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab -o yaml --dry-run=client > ktutil_keytab.yaml
+
+# apply the secret
+kubectl apply -f ./ktutil_keytab.yaml

--- a/resources/common/ktutil-keytab.sh
+++ b/resources/common/ktutil-keytab.sh
@@ -30,3 +30,17 @@ kubectl create secret generic kerberos-keytab -n $NS --from-file=./client.keytab
 
 # apply the secret
 kubectl apply -f ./ktutil_keytab.yaml
+
+
+#get the notebook name
+nb_name=${NB_PREFIX##*/}
+
+# Prompt user for notebook restart
+while true; do
+    read -p "In order to update the kerberos authentication, the notebook server needs to be restarted. Would you like to restart your notebook server?[Y/n]: " yn
+    case $yn in
+        [Yy]* ) echo "Your notebook server will now restart"; kubectl rollout restart statefulset $nb_name -n $NB_NAMESPACE; break;;
+        [Nn]* ) echo "Your notebook server will not be restarted"; exit;;
+        * ) echo "Only yes or no is an expected answer";;
+    esac
+done

--- a/resources/common/ktutil-keytab.sh
+++ b/resources/common/ktutil-keytab.sh
@@ -3,6 +3,11 @@
 mkdir -p ~/krb5
 cd ~/krb5
 
+#clean up from previous run(or else it appends to the file instead of replacing it)
+if [ -f ./client.keytab ]; then
+    rm ./client.keytab
+fi
+
 # gets the user's username (legacy AD)
 read -p "Username(ex. marcoma):" user_name
 


### PR DESCRIPTION
# Description

for https://jirab.statcan.ca/browse/BTIS-700 

# Tests / Quality Checks

Can be tested by running "ktutil-keytab" in a terminal in a running notebook

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
