### PR TITLE
Enable Hadolint to fail builds

### DIFF
--- a/.github/workflows/docker-build-upload.yaml
+++ b/.github/workflows/docker-build-upload.yaml
@@ -91,7 +91,7 @@ jobs:
         run: |
           sudo curl -L https://github.com/hadolint/hadolint/releases/download/v${{ env.HADOLINT_VERSION }}/hadolint-Linux-x86_64 --output hadolint
           sudo chmod +x hadolint
-          ./hadolint images/${{ inputs.directory }}/Dockerfile
+          ./hadolint images/${{ inputs.directory }}/Dockerfile --failure-threshold error
 
       # make build emits full_image_name, image_tag, and image_repo outputs
       - name: Build image

--- a/.github/workflows/docker-build-upload.yaml
+++ b/.github/workflows/docker-build-upload.yaml
@@ -54,12 +54,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run Hadolint
-        run: |
-          sudo curl -L https://github.com/hadolint/hadolint/releases/download/v${{ env.HADOLINT_VERSION }}/hadolint-Linux-x86_64 --output hadolint
-          sudo chmod +x hadolint
-          ./hadolint images/${{ inputs.directory }}/Dockerfile --no-fail
-
       - name: Echo disk usage before clean up
         run: ./.github/scripts/echo_usage.sh
 
@@ -92,6 +86,12 @@ jobs:
       - name: Set FROM and as in Docerfile
         run: |
           sed -i '1i FROM ${{ env.BASE_IMAGE}} as ${{ inputs.image }}' ./images/${{ inputs.directory }}/Dockerfile
+
+      - name: Run Hadolint
+        run: |
+          sudo curl -L https://github.com/hadolint/hadolint/releases/download/v${{ env.HADOLINT_VERSION }}/hadolint-Linux-x86_64 --output hadolint
+          sudo chmod +x hadolint
+          ./hadolint images/${{ inputs.directory }}/Dockerfile --no-fail
 
       # make build emits full_image_name, image_tag, and image_repo outputs
       - name: Build image

--- a/.github/workflows/docker-build-upload.yaml
+++ b/.github/workflows/docker-build-upload.yaml
@@ -91,7 +91,7 @@ jobs:
         run: |
           sudo curl -L https://github.com/hadolint/hadolint/releases/download/v${{ env.HADOLINT_VERSION }}/hadolint-Linux-x86_64 --output hadolint
           sudo chmod +x hadolint
-          ./hadolint images/${{ inputs.directory }}/Dockerfile --no-fail
+          ./hadolint images/${{ inputs.directory }}/Dockerfile
 
       # make build emits full_image_name, image_tag, and image_repo outputs
       - name: Build image

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,3 +1,4 @@
+FROM quay.io/jupyter/datascience-notebook:2024-06-17 as base
 USER root
 
 ENV PATH="/home/jovyan/.local/bin/:${PATH}"
@@ -82,7 +83,7 @@ RUN \
     && curl -LO "${KUBECTL_URL}.sha256" \
     && echo "$(cat kubectl.sha256) kubectl" | sha256sum -c - \
     && chmod +x ./kubectl \
-    && sudo mv ./kubectl /usr/local/bin/kubectl \
+    && mv ./kubectl /usr/local/bin/kubectl \
   && \
     # AzureCLI - installation script from Azure
     curl -sLO "${AZCLI_URL}" \
@@ -100,7 +101,7 @@ RUN \
     && echo "${TRINO_SHA}" /tmp/trino-original | sha256sum -c \
     && echo "trinocli: ok" \
     && chmod +x /tmp/trino-original \
-    && sudo mv /tmp/trino-original /usr/local/bin/trino-original \
+    && mv /tmp/trino-original /usr/local/bin/trino-original \
   && \
     # argo cli
     curl -sLO  "${ARGO_CLI_URL}" \
@@ -108,7 +109,7 @@ RUN \
     && grep argo-linux-amd64.gz argo-workflows-cli-checksums.txt | sha256sum -c - \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
-    && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
+    && mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version \
   && \
     # quarto
@@ -117,8 +118,8 @@ RUN \
     && grep "quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" "quarto-${QUARTO_VERSION}-checksums.txt" | sha256sum -c - \
     && tar -xf "quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" \
     && chmod +x "quarto-${QUARTO_VERSION}" \
-    && sudo rm -f /usr/local/bin/quarto \
-    && sudo mv "./quarto-${QUARTO_VERSION}" /usr/local/bin/quarto 
+    && rm -f /usr/local/bin/quarto \
+    && mv "./quarto-${QUARTO_VERSION}" /usr/local/bin/quarto 
 
 # ODBC drivers
 RUN apt-get update && \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -23,10 +23,10 @@ RUN mamba install --quiet \
       's3fs' \ 
       'fire==0.5.0' \
       'graphviz' && \
-      pip install 'kubeflow-training' && \
+      pip install --no-cache-dir 'kubeflow-training' && \
       clean-layer.sh && \
-      fix-permissions $CONDA_DIR && \
-      fix-permissions /home/$NB_USER && \
+      fix-permissions "$CONDA_DIR" && \
+      fix-permissions "/home/$NB_USER" && \
       chmod +x /usr/local/bin/aaw-suspend-server.sh
 
 # Add helpers for shell initialization
@@ -74,8 +74,8 @@ RUN \
     apt-get update && \
     apt-get install -y openjdk-8-jre && \
     apt-get clean && \
-    fix-permissions $CONDA_DIR && \
-    fix-permissions /home/$NB_USER \
+    fix-permissions "$CONDA_DIR" && \
+    fix-permissions "/home/$NB_USER" \
   && \
     # kubectl
     curl -LO "${KUBECTL_URL}" \
@@ -97,14 +97,14 @@ RUN \
   && \
     # trino cli
     wget -q "${TRINO_URL}" -O /tmp/trino-original \
-    && echo ${TRINO_SHA} /tmp/trino-original | sha256sum -c \
+    && echo "${TRINO_SHA}" /tmp/trino-original | sha256sum -c \
     && echo "trinocli: ok" \
     && chmod +x /tmp/trino-original \
     && sudo mv /tmp/trino-original /usr/local/bin/trino-original \
   && \
     # argo cli
-    curl -sLO  ${ARGO_CLI_URL}\
-    && curl -LO ${ARGO_CLI_CHECKSUM_URL} \
+    curl -sLO  "${ARGO_CLI_URL}" \
+    && curl -LO "${ARGO_CLI_CHECKSUM_URL}" \
     && grep argo-linux-amd64.gz argo-workflows-cli-checksums.txt | sha256sum -c - \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
@@ -112,21 +112,21 @@ RUN \
     && argo version \
   && \
     # quarto
-    curl -sLO  ${QUARTO_URL} \
-    && curl -LO ${QUARTO_CHECKSUM_URL} \
-    && grep "quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" quarto-${QUARTO_VERSION}-checksums.txt | sha256sum -c - \
-    && tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
-    && chmod +x quarto-${QUARTO_VERSION} \
+    curl -sLO  "${QUARTO_URL}" \
+    && curl -LO "${QUARTO_CHECKSUM_URL}" \
+    && grep "quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" "quarto-${QUARTO_VERSION}-checksums.txt" | sha256sum -c - \
+    && tar -xf "quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" \
+    && chmod +x "quarto-${QUARTO_VERSION}" \
     && sudo rm -f /usr/local/bin/quarto \
-    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto 
+    && sudo mv "./quarto-${QUARTO_VERSION}" /usr/local/bin/quarto 
 
 # ODBC drivers
 RUN apt-get update && \
     apt-get install -y unixodbc-dev && \
     pip install --no-cache-dir --quiet pyodbc && \
     rm -rf /var/lib/apt/lists/* && \
-    fix-permissions $CONDA_DIR && \
-    fix-permissions /home/$NB_USER
+    fix-permissions "$CONDA_DIR" && \
+    fix-permissions "/home/$NB_USER"
 
 # Forcibly upgrade packages to patch vulnerabilities
 # See https://github.com/StatCan/aaw-private/issues/58#issuecomment-1471863092 for more details.
@@ -182,7 +182,7 @@ COPY vscode-overrides.json $CS_TEMP_HOME/Machine/settings.json
 # Languagepacks.json needs to exist for code-server to recognize the languagepack
 COPY languagepacks.json $CS_TEMP_HOME/
 
-RUN pip install \
+RUN pip install --no-cache-dir \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \
@@ -209,10 +209,10 @@ RUN pip install \
     jupyter lab build && \
     jupyter lab clean && \
   clean-layer.sh && \
-  rm -rf /home/$NB_USER/.cache/yarn && \
-  rm -rf /home/$NB_USER/.node-gyp && \
-  fix-permissions $CONDA_DIR && \
-  fix-permissions /home/$NB_USER
+  rm -rf "/home/$NB_USER/.cache/yarn" && \
+  rm -rf "/home/$NB_USER/.node-gyp" && \
+  fix-permissions "$CONDA_DIR" && \
+  fix-permissions "/home/$NB_USER"
 
 # Update and pin packages
 # See https://github.com/StatCan/aaw-kubeflow-containers/issues/293
@@ -232,8 +232,8 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
     'unified-language-server' \
     'yaml-language-server' && \
     clean-layer.sh && \ 
-    fix-permissions $CONDA_DIR && \
-    fix-permissions /home/$NB_USER
+    fix-permissions "$CONDA_DIR" && \
+    fix-permissions "/home/$NB_USER"
 
 # OpenM install
 # Install OpenM++ MPI
@@ -267,7 +267,7 @@ RUN apt-get update --yes \
     && rm -r ${OMPP_INSTALL_DIR}/html \
     && mv ${OMPP_INSTALL_DIR}/ompp-ui/dist/spa ${OMPP_INSTALL_DIR}/html \
     && fix-permissions ${OMPP_INSTALL_DIR} \
-    && pip install /opt/jupyter-ompp-proxy/
+    && pip install --no-cache-dir /opt/jupyter-ompp-proxy/
 
 # Solarized Theme and Cell Execution Time
 COPY jupyterlab-overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,4 +1,3 @@
-FROM quay.io/jupyter/datascience-notebook:2024-06-17 as base
 USER root
 
 ENV PATH="/home/jovyan/.local/bin/:${PATH}"

--- a/images/cmd/Dockerfile
+++ b/images/cmd/Dockerfile
@@ -29,7 +29,7 @@ RUN conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8
     conda config --add channels http://jfrog-platform-artifactory.jfrog-system:8081/artifactory/api/conda/conda-pytorch-remote --system
 
 # Assign ownership of user's home directory to user
-RUN chown $NB_USER:users /home/$NB_USER
+RUN chown "$NB_USER:users" "/home/$NB_USER"
 
 USER $NB_USER
 ENTRYPOINT ["tini", "--"]

--- a/images/platform/Dockerfile
+++ b/images/platform/Dockerfile
@@ -10,7 +10,7 @@ RUN \
     echo "${AOCL_SHA256} /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar" | sha256sum -c - && \
     tar xf "/tmp/aocl-linux-aocc-${AOCL_VERSION}.tar" -C ./ && \
     /bin/bash "./aocl-linux-aocc-${AOCL_VERSION}/install.sh" -t /opt/amd/aocl && \
-    cp setenv_aocl.sh ${AOCL_PATH} &&\
+    cp "./aocl-linux-aocc-${AOCL_VERSION}/setenv_aocl.sh" ${AOCL_PATH} &&\
     rm "/tmp/aocl-linux-aocc-${AOCL_VERSION}.tar"
 
 # Install AMD AOCC

--- a/images/platform/Dockerfile
+++ b/images/platform/Dockerfile
@@ -4,22 +4,22 @@ USER root
 ARG AOCL_VERSION=4.0
 ENV AOCL_PATH=/opt/amd/aocl/${AOCL_VERSION}
 ARG AOCL_SHA256=8a249e727beb8005639b4887074e1ea75020267ed1ac25520876a7ad21d0f4f6
-RUN cd "${RESOURCES_PATH}" && \
+WORKDIR ${RESOURCES_PATH}
+RUN \
     wget --quiet "https://download.amd.com/developer/eula/aocl/aocl-4-0/aocl-linux-aocc-${AOCL_VERSION}.tar.gz" -O "/tmp/aocl-linux-aocc-${AOCL_VERSION}.tar" && \
     echo "${AOCL_SHA256} /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar" | sha256sum -c - && \
     tar xf "/tmp/aocl-linux-aocc-${AOCL_VERSION}.tar" -C ./ && \
-    cd "./aocl-linux-aocc-${AOCL_VERSION}" && \
-    /bin/bash ./install.sh -t /opt/amd/aocl && \
+    /bin/bash "./aocl-linux-aocc-${AOCL_VERSION}/install.sh" -t /opt/amd/aocl && \
     cp setenv_aocl.sh ${AOCL_PATH} &&\
     rm "/tmp/aocl-linux-aocc-${AOCL_VERSION}.tar"
 
 # Install AMD AOCC
 ARG AOCC_VERSION=4.0.0
 ARG AOCC_SHA256=2729ec524cbc927618e479994330eeb72df5947e90cfcc49434009eee29bf7d4
-RUN cd "${RESOURCES_PATH}" && \
+WORKDIR ${RESOURCES_PATH}
+RUN \
    wget --quiet https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-${AOCC_VERSION}.tar -O /tmp/aocc-compiler-${AOCC_VERSION}.tar && \
    echo "${AOCC_SHA256} /tmp/aocc-compiler-${AOCC_VERSION}.tar" | sha256sum -c - && \
    tar xf /tmp/aocc-compiler-${AOCC_VERSION}.tar -C ./ && \
-   cd ./aocc-compiler-${AOCC_VERSION} && \
-   /bin/bash ./install.sh && \
+   /bin/bash ./aocc-compiler-${AOCC_VERSION}/install.sh && \
    rm /tmp/aocc-compiler-${AOCC_VERSION}.tar

--- a/images/platform/Dockerfile
+++ b/images/platform/Dockerfile
@@ -4,19 +4,19 @@ USER root
 ARG AOCL_VERSION=4.0
 ENV AOCL_PATH=/opt/amd/aocl/${AOCL_VERSION}
 ARG AOCL_SHA256=8a249e727beb8005639b4887074e1ea75020267ed1ac25520876a7ad21d0f4f6
-RUN cd ${RESOURCES_PATH} && \
-    wget --quiet https://download.amd.com/developer/eula/aocl/aocl-4-0/aocl-linux-aocc-${AOCL_VERSION}.tar.gz -O /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar && \
+RUN cd "${RESOURCES_PATH}" && \
+    wget --quiet "https://download.amd.com/developer/eula/aocl/aocl-4-0/aocl-linux-aocc-${AOCL_VERSION}.tar.gz" -O "/tmp/aocl-linux-aocc-${AOCL_VERSION}.tar" && \
     echo "${AOCL_SHA256} /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar" | sha256sum -c - && \
-    tar xf /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar -C ./ && \
-    cd ./aocl-linux-aocc-${AOCL_VERSION} && \
+    tar xf "/tmp/aocl-linux-aocc-${AOCL_VERSION}.tar" -C ./ && \
+    cd "./aocl-linux-aocc-${AOCL_VERSION}" && \
     /bin/bash ./install.sh -t /opt/amd/aocl && \
     cp setenv_aocl.sh ${AOCL_PATH} &&\
-    rm /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar
+    rm "/tmp/aocl-linux-aocc-${AOCL_VERSION}.tar"
 
 # Install AMD AOCC
 ARG AOCC_VERSION=4.0.0
 ARG AOCC_SHA256=2729ec524cbc927618e479994330eeb72df5947e90cfcc49434009eee29bf7d4
-RUN cd ${RESOURCES_PATH} && \
+RUN cd "${RESOURCES_PATH}" && \
    wget --quiet https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-${AOCC_VERSION}.tar -O /tmp/aocc-compiler-${AOCC_VERSION}.tar && \
    echo "${AOCC_SHA256} /tmp/aocc-compiler-${AOCC_VERSION}.tar" | sha256sum -c - && \
    tar xf /tmp/aocc-compiler-${AOCC_VERSION}.tar -C ./ && \

--- a/images/pytorch/Dockerfile
+++ b/images/pytorch/Dockerfile
@@ -11,7 +11,7 @@ RUN mamba create -n torch && \
         # pytorch-cuda are the nvidia cuda drivers
         pytorch-cuda=11.8 && \
     clean-layer.sh && \
-    fix-permissions $CONDA_DIR && \
-    fix-permissions /home/$NB_USER && \
+    fix-permissions "$CONDA_DIR" && \
+    fix-permissions "/home/$NB_USER" && \
     python -m ipykernel install --user --name torch --display-name "PyTorch"
 

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -1,4 +1,3 @@
-FROM dummy as testing
 # For compatibility with docker stacks
 ARG HOME=/home/$NB_USER
 ARG NB_USER="jovyan"

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -253,7 +253,7 @@ RUN \
 #None of these are installed in upstream docker images but are present in current remote
 RUN \
     apt-get update --fix-missing && \
-    apt-get install -y apt-utils && \
+    apt-get install -y sudo apt-utils && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         # This is necessary for apt to access HTTPS sources:

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -393,14 +393,12 @@ RUN apt-get update --yes \
 # https://github.com/cdr/code-server/issues/171
 ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
 ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
-
-RUN mkdir -p "$RESOURCES_PATH/$HOME/.local/share" \
- && mkdir -p "$RESOURCES_PATH/$VSCODE_DIR/extensions"
-
 ENV VS_PYTHON_VERSION="2020.5.86806" 
 
 WORKDIR ${RESOURCES_PATH}
-RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix \
+RUN  mkdir -p $HOME/.local/share \
+ && mkdir -p $VSCODE_DIR/extensions \
+ && wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix \
  && echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - \
  && bsdtar -xf ms-python-release.vsix extension \
  && rm ms-python-release.vsix \

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update --yes \
     && rm -rf /var/lib/apt/lists/*
 
 RUN /rocker_scripts/install_shiny_server.sh \
-    && pip3 install jupyter \
+    && pip3 install --no-cache-dir jupyter \
     && rm -rf /var/lib/apt/lists/* 
 
 # Users should install R packages in their home directory
@@ -78,10 +78,10 @@ RUN mamba install --quiet \
       's3fs' \ 
       'fire==0.5.0' \
       'graphviz' && \
-      pip install 'kubeflow-training' && \
+      pip install --no-cache-dir 'kubeflow-training' && \
       clean-layer.sh && \
-      fix-permissions $CONDA_DIR && \
-      fix-permissions /home/$NB_USER && \
+      fix-permissions "$CONDA_DIR" && \
+      fix-permissions "/home/$NB_USER" && \
       chmod +x /usr/local/bin/aaw-suspend-server.sh
 
 # Add helpers for shell initialization
@@ -356,7 +356,7 @@ RUN \
     # Cleanup
     clean-layer.sh
 
-RUN pip3 install --quiet 'selenium' && \
+RUN pip3 install --quiet --no-cache-dir 'selenium' && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
@@ -536,7 +536,6 @@ RUN rm /usr/share/applications/exo-mail-reader.desktop
 #Prevent screen from locking
 RUN apt-get remove -y -q light-locker
 
-
 # apt-get may result in root-owned directories/files under $HOME
 RUN usermod -l $NB_USER rstudio && \
     chown -R $NB_UID:$NB_GID $HOME
@@ -547,7 +546,6 @@ ENV NB_NAMESPACE=$NB_NAMESPACE
 RUN apt-get update && apt-get install --yes websockify \
     && cp /usr/lib/websockify/rebind.cpython-38-x86_64-linux-gnu.so /usr/lib/websockify/rebind.so \
     && clean-layer.sh
-
 
 #Set Defaults
 ENV HOME=/home/$NB_USER

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -599,7 +599,7 @@ RUN \
     echo "${AOCL_SHA256} /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar" | sha256sum -c - && \
     tar xf /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar -C ./ && \
     /bin/bash ./aocl-linux-aocc-${AOCL_VERSION}/install.sh -t /opt/amd/aocl && \
-    cp setenv_aocl.sh ${AOCL_PATH} &&\
+    cp  ./aocl-linux-aocc-${AOCL_VERSION}/setenv_aocl.sh ${AOCL_PATH} &&\
     rm /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar
 
 # Install AMD AOCC

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -138,7 +138,7 @@ RUN \
     && curl -LO "${KUBECTL_URL}.sha256" \
     && echo "$(cat kubectl.sha256) kubectl" | sha256sum -c - \
     && chmod +x ./kubectl \
-    && sudo mv ./kubectl /usr/local/bin/kubectl \
+    && mv ./kubectl /usr/local/bin/kubectl \
   && \
     # AzureCLI - installation script from Azure
     curl -sLO "${AZCLI_URL}" \
@@ -156,7 +156,7 @@ RUN \
     && echo ${TRINO_SHA} /tmp/trino-original | sha256sum -c \
     && echo "trinocli: ok" \
     && chmod +x /tmp/trino-original \
-    && sudo mv /tmp/trino-original /usr/local/bin/trino-original \
+    && mv /tmp/trino-original /usr/local/bin/trino-original \
   && \
     # argo cli
     curl -sLO  ${ARGO_CLI_URL}\
@@ -164,7 +164,7 @@ RUN \
     && grep argo-linux-amd64.gz argo-workflows-cli-checksums.txt | sha256sum -c - \
     && gunzip argo-linux-amd64.gz \
     && chmod +x argo-linux-amd64 \
-    && sudo mv ./argo-linux-amd64 /usr/local/bin/argo \
+    && mv ./argo-linux-amd64 /usr/local/bin/argo \
     && argo version \
   && \
     # quarto
@@ -173,8 +173,8 @@ RUN \
     && grep "quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" quarto-${QUARTO_VERSION}-checksums.txt | sha256sum -c - \
     && tar -xf quarto-${QUARTO_VERSION}-linux-amd64.tar.gz \
     && chmod +x quarto-${QUARTO_VERSION} \
-    && sudo rm -f /usr/local/bin/quarto \
-    && sudo mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
+    && rm -f /usr/local/bin/quarto \
+    && mv ./quarto-${QUARTO_VERSION} /usr/local/bin/quarto
     
 ENV NB_UID=1000
 ENV NB_GID=100
@@ -253,7 +253,7 @@ RUN \
 #None of these are installed in upstream docker images but are present in current remote
 RUN \
     apt-get update --fix-missing && \
-    apt-get install -y sudo apt-utils && \
+    apt-get install -y apt-utils && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         # This is necessary for apt to access HTTPS sources:
@@ -418,17 +418,17 @@ RUN git clone -vb release/$VS_LOCALE_REPO_VERSION https://github.com/microsoft/v
 WORKDIR $NODE_VERSION_ARCH
 
 RUN if [ -f /usr/bin/node ]; then \
-    sudo mv -f /usr/bin/node /usr/bin/node.old; \
+    mv -f /usr/bin/node /usr/bin/node.old; \
     fi \
  && if [ -f /usr/bin/npm ]; then \
-    sudo mv -f /usr/bin/npm /usr/bin/npm.old; \
+    mv -f /usr/bin/npm /usr/bin/npm.old; \
     fi \
  && if [ -f /usr/bin/npx ]; then \
-    sudo mv -f /usr/bin/npx /usr/bin/npx.old; \
+    mv -f /usr/bin/npx /usr/bin/npx.old; \
     fi \
- && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
- && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
- && sudo ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx \
+ && ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/node /usr/bin/node \
+ && ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npm /usr/bin/npm \
+ && ln -sfv /tmp/vscode-lang-pack-install/$NODE_VERSION_ARCH/bin/npx /usr/bin/npx \
  && npm install @vscode/vsce
 
 WORKDIR /tmp/vscode-lang-pack-install/vscode-loc/i18n/vscode-language-pack-fr 
@@ -442,13 +442,13 @@ WORKDIR /tmp
 
 RUN rm -fr vscode-lang-pack-install \
  && if [ -f /usr/bin/node.old ]; then \
-    sudo mv -f /usr/bin/node.old /usr/bin/node; \
+    mv -f /usr/bin/node.old /usr/bin/node; \
     fi \
  && if [ -f /usr/bin/npm.old ]; then \
-    sudo mv -f /usr/bin/npm.old /usr/bin/npm; \
+    mv -f /usr/bin/npm.old /usr/bin/npm; \
     fi \
  && if [ -f /usr/bin/npx.old ]; then \
-    sudo mv -f /usr/bin/npx.old /usr/bin/npx; \
+    mv -f /usr/bin/npx.old /usr/bin/npx; \
     fi \
  && fix-permissions $XDG_DATA_HOME \
  && clean-layer.sh

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -394,10 +394,11 @@ RUN apt-get update --yes \
 ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
 ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
 
-RUN cd $RESOURCES_PATH \
- && mkdir -p $HOME/.local/share \
- && mkdir -p $VSCODE_DIR/extensions 
+RUN mkdir -p "$RESOURCES_PATH/$HOME/.local/share" \
+ && mkdir -p "$RESOURCES_PATH/$VSCODE_DIR/extensions"
+
 ENV VS_PYTHON_VERSION="2020.5.86806" 
+
 RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix \
  && echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - \
  && bsdtar -xf ms-python-release.vsix extension \
@@ -510,8 +511,8 @@ COPY French/vscode/languagepacks.json /home/$NB_USER/.config/Code/
 
 #Tiger VNC
 ARG SHA256tigervnc=fb8f94a5a1d77de95ec8fccac26cb9eaa9f9446c664734c68efdffa577f96a31
+WORKDIR ${RESOURCES_PATH}
 RUN \
-    cd ${RESOURCES_PATH} && \
     wget --quiet https://sourceforge.net/projects/tigervnc/files/stable/1.10.1/tigervnc-1.10.1.x86_64.tar.gz/ -O /tmp/tigervnc.tar.gz && \
     echo "${SHA256tigervnc} /tmp/tigervnc.tar.gz" | sha256sum -c - && \
     tar xzf /tmp/tigervnc.tar.gz --strip 1 -C / && \
@@ -593,24 +594,24 @@ RUN pip3 --no-cache-dir install --quiet \
 ARG AOCL_VERSION=4.0
 ENV AOCL_PATH=/opt/amd/aocl/${AOCL_VERSION}
 ARG AOCL_SHA256=8a249e727beb8005639b4887074e1ea75020267ed1ac25520876a7ad21d0f4f6
-RUN cd ${RESOURCES_PATH} && \
+WORKDIR ${RESOURCES_PATH}
+RUN \
     wget --quiet https://download.amd.com/developer/eula/aocl/aocl-4-0/aocl-linux-aocc-${AOCL_VERSION}.tar.gz -O /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar && \
     echo "${AOCL_SHA256} /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar" | sha256sum -c - && \
     tar xf /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar -C ./ && \
-    cd ./aocl-linux-aocc-${AOCL_VERSION} && \
-    /bin/bash ./install.sh -t /opt/amd/aocl && \
+    /bin/bash ./aocl-linux-aocc-${AOCL_VERSION}/install.sh -t /opt/amd/aocl && \
     cp setenv_aocl.sh ${AOCL_PATH} &&\
     rm /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar
 
 # Install AMD AOCC
 ARG AOCC_VERSION=4.0.0
 ARG AOCC_SHA256=2729ec524cbc927618e479994330eeb72df5947e90cfcc49434009eee29bf7d4
-RUN cd ${RESOURCES_PATH} && \
+WORKDIR ${RESOURCES_PATH}
+RUN \
    wget --quiet https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-${AOCC_VERSION}.tar -O /tmp/aocc-compiler-${AOCC_VERSION}.tar && \
    echo "${AOCC_SHA256} /tmp/aocc-compiler-${AOCC_VERSION}.tar" | sha256sum -c - && \
    tar xf /tmp/aocc-compiler-${AOCC_VERSION}.tar -C ./ && \
-   cd ./aocc-compiler-${AOCC_VERSION} && \
-   /bin/bash ./install.sh && \
+   /bin/bash ./aocc-compiler-${AOCC_VERSION}/install.sh && \
    rm /tmp/aocc-compiler-${AOCC_VERSION}.tar
 
 

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -1,3 +1,4 @@
+FROM dummy as testing
 # For compatibility with docker stacks
 ARG HOME=/home/$NB_USER
 ARG NB_USER="jovyan"
@@ -399,6 +400,7 @@ RUN mkdir -p "$RESOURCES_PATH/$HOME/.local/share" \
 
 ENV VS_PYTHON_VERSION="2020.5.86806" 
 
+WORKDIR ${RESOURCES_PATH}
 RUN wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix \
  && echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - \
  && bsdtar -xf ms-python-release.vsix extension \

--- a/images/rstudio/Dockerfile
+++ b/images/rstudio/Dockerfile
@@ -37,15 +37,15 @@ RUN conda install --quiet --yes \
       'r-markdown' \
     && \
     clean-layer.sh && \
-    fix-permissions $CONDA_DIR && \
-    fix-permissions /home/$NB_USER
+    fix-permissions "$CONDA_DIR" && \
+    fix-permissions "/home/$NB_USER"
 
-RUN python3 -m pip install \
+RUN python3 -m pip install --no-cache-dir \
       'jupyter-rsession-proxy==2.2.0' \
       'jupyter-server-proxy==4.2.0' \
       'jupyter-shiny-proxy==1.1' && \
-      fix-permissions $CONDA_DIR && \
-      fix-permissions /home/$NB_USER
+      fix-permissions "$CONDA_DIR" && \
+      fix-permissions "/home/$NB_USER"
 
 # If using the docker bit in other Dockerfiles, this must get written over in a later layer
 ENV DEFAULT_JUPYTER_URL="/rstudio"

--- a/images/rstudio/Dockerfile
+++ b/images/rstudio/Dockerfile
@@ -2,11 +2,11 @@
 ARG RSTUDIO_VERSION=2024.04.2-764
 ARG SHA256=d8ffb8e5c2dadb1c74df037c291a5585e595d978b3aec48a4a94a970e04a947d
 RUN apt-get update && \
-    apt install -y --no-install-recommends software-properties-common dirmngr gdebi-core && \
+    apt-get install -y --no-install-recommends software-properties-common dirmngr gdebi-core && \
     wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc && \
     add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/" && \
-    apt install -y --no-install-recommends r-base r-base-core r-recommended r-base-dev && \
-    apt-get update && apt-get -y dist-upgrade
+    apt-get install -y --no-install-recommends r-base r-base-core r-recommended r-base-dev && \
+    apt-get -y upgrade
 RUN curl --silent -L  --fail "https://s3.amazonaws.com/rstudio-ide-build/server/jammy/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" > /tmp/rstudio.deb && \
     echo "${SHA256} /tmp/rstudio.deb" | sha256sum -c - && \
     apt-get install --no-install-recommends -y /tmp/rstudio.deb && \

--- a/images/rstudio/Dockerfile
+++ b/images/rstudio/Dockerfile
@@ -3,7 +3,7 @@ ARG RSTUDIO_VERSION=2024.04.2-764
 ARG SHA256=d8ffb8e5c2dadb1c74df037c291a5585e595d978b3aec48a4a94a970e04a947d
 RUN apt-get update && \
     apt install -y --no-install-recommends software-properties-common dirmngr gdebi-core && \
-    wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc && \
+    wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc && \
     add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/" && \
     apt install -y --no-install-recommends r-base r-base-core r-recommended r-base-dev && \
     apt-get update && apt-get -y dist-upgrade

--- a/images/sas/Dockerfile
+++ b/images/sas/Dockerfile
@@ -35,7 +35,7 @@ EXPOSE 8561 8591 38080
 
 ENV SASPY_VERSION="5.4.0"
 
-RUN pip install sas_kernel
+RUN pip install --no-cache-dir sas_kernel
 
 # TODO: make Python version ENV var.
 COPY sascfg.py /opt/conda/lib/python3.11/site-packages/saspy/sascfg.py
@@ -49,7 +49,7 @@ RUN jupyter nbextension install --py sas_kernel.showSASLog && \
 # Jupyter SASStudio Proxy
 
 COPY jupyter-sasstudio-proxy/ /opt/jupyter-sasstudio-proxy/
-RUN pip install /opt/jupyter-sasstudio-proxy/
+RUN pip install --no-cache-dir /opt/jupyter-sasstudio-proxy/
 
 # Must be set in deepest image
 ENV DEFAULT_JUPYTER_URL=/lab 

--- a/images/tensorflow/Dockerfile
+++ b/images/tensorflow/Dockerfile
@@ -17,7 +17,7 @@ ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 curl ca-certificates && \
-    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/${OS_VER}/${NVARCH}/3bf863cc.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/nvidia.gpg && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/${OS_VER}/${NVARCH}/3bf863cc.pub | gpg --dearmor | tee /etc/apt/trusted.gpg.d/nvidia.gpg && \
     echo "deb https://developer.download.nvidia.com/compute/cuda/repos/${OS_VER}/${NVARCH} /" > /etc/apt/sources.list.d/cuda.list && \
     apt-get purge --autoremove -y curl \
     && rm -rf /var/lib/apt/lists/*

--- a/images/tensorflow/Dockerfile
+++ b/images/tensorflow/Dockerfile
@@ -117,5 +117,5 @@ RUN mamba install --quiet --yes \
         ipykernel \
     && \
     clean-layer.sh && \
-    fix-permissions $CONDA_DIR && \
-    fix-permissions /home/$NB_USER
+    fix-permissions "$CONDA_DIR" && \
+    fix-permissions "/home/$NB_USER"


### PR DESCRIPTION
investigates removing `--no-fail` from Hadolint

Part of https://github.com/StatCan/aaw-kubeflow-containers/issues/732

Hadolint checks had to be moved below the `FROM *** as ***` injection, or would else error out on the missing `FROM`

Fixes made for

- fixes https://github.com/hadolint/hadolint/wiki/DL3003 (Use absolute paths, or use WORKDIR to switch to a directory)
- fixes https://github.com/hadolint/hadolint/wiki/DL3004 (Do not use sudo)
- fixes https://github.com/hadolint/hadolint/wiki/DL3005 (Do not use apt-get dist-upgrade)
- fixes https://github.com/hadolint/hadolint/wiki/DL3027 (Do not use apt, it is an end-user tool, use apt-get instead)
- fixes https://github.com/hadolint/hadolint/wiki/DL3042 (Avoid cache directory with pip install --no-cache-dir)
- fixes https://github.com/koalaman/shellcheck/wiki/SC2086 (Double quote to prevent globbing and word splitting)