### PR TITLE
fix nightly

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -8,8 +8,8 @@ jobs:
   vars:
     runs-on: ubuntu-latest
     outputs:
-      REGISTRY_NAME: "k8scc01covidacr"
-      DEV_REGISTRY_NAME: "k8scc01covidacrdev"
+      REGISTRY_NAME: "k8scc01covidacr.azurecr.io"
+      DEV_REGISTRY_NAME: "k8scc01covidacrdev.azurecr.io"
       branch-name: "master"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Late in Dev I changed the registry to be the whole url `k8scc01covidacr.azurecr.io` instead of just being the one part `k8scc01covidacr`.

This wasn't changed in `docker-nightly.yaml`, so the builds failed last night.  