### PR TITLE
fix: tnsnames.ora clone script fix

### DIFF
--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -213,7 +213,10 @@ ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "${ORACLE_ADMIN_PATH}/515" \
+    && mv "${ORACLE_ADMIN_PATH}/515/tnsnames.ora" "${ORACLE_ADMIN_PATH}" \
+    && rm -rf "${ORACLE_ADMIN_PATH}/515" \
+    && break
   echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
   [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"

--- a/output/docker-stacks-datascience-notebook/start-custom.sh
+++ b/output/docker-stacks-datascience-notebook/start-custom.sh
@@ -33,7 +33,7 @@ if [[ ! -d  ~/aaw-contrib-jupyter-notebooks ]]; then
   RETRY_DELAY=3
   for i in $(seq 1 $RETRIES_NO); do
     test -z "$GIT_EXAMPLE_NOTEBOOKS" || git clone "$GIT_EXAMPLE_NOTEBOOKS" && break
-    echo "Failed to cloned the example notebooks. Attempt $i of $RETRIES_NO"
+    echo "Failed to clone the example notebooks. Attempt $i of $RETRIES_NO"
     #if it ran all the retries, exit
     [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone example notebooks after $RETRIES_NO retries"
     sleep ${RETRY_DELAY}
@@ -208,13 +208,15 @@ fi
 # Runs on every startup because this output location is not persisted storage
 # Implemented with a retry because it sometimes fails for some reason
 echo "Retrieving Oracle tnsnames file"
+GIT_ORACLE_SNIPPET="https://gitlab.k8s.cloud.statcan.ca/business-transformation/aaw/aaw-contrib-containers/snippets/515.git"
+ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  curl --url "https://gitlab.k8s.cloud.statcan.ca/api/v4/snippets/515/raw" -o /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora && break
-  echo "Failed to get the tnsnames.ora file. Attempt $i of $RETRIES_NO"
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
-  [[ $i -eq $RETRIES_NO ]] && echo "Failed to get the tnsnames.ora file after $RETRIES_NO retries"
+  [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"
   sleep ${RETRY_DELAY}
 done
 

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -213,7 +213,10 @@ ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "${ORACLE_ADMIN_PATH}/515" \
+    && mv "${ORACLE_ADMIN_PATH}/515/tnsnames.ora" "${ORACLE_ADMIN_PATH}" \
+    && rm -rf "${ORACLE_ADMIN_PATH}/515" \
+    && break
   echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
   [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"

--- a/output/jupyterlab-cpu/start-custom.sh
+++ b/output/jupyterlab-cpu/start-custom.sh
@@ -33,7 +33,7 @@ if [[ ! -d  ~/aaw-contrib-jupyter-notebooks ]]; then
   RETRY_DELAY=3
   for i in $(seq 1 $RETRIES_NO); do
     test -z "$GIT_EXAMPLE_NOTEBOOKS" || git clone "$GIT_EXAMPLE_NOTEBOOKS" && break
-    echo "Failed to cloned the example notebooks. Attempt $i of $RETRIES_NO"
+    echo "Failed to clone the example notebooks. Attempt $i of $RETRIES_NO"
     #if it ran all the retries, exit
     [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone example notebooks after $RETRIES_NO retries"
     sleep ${RETRY_DELAY}
@@ -208,13 +208,15 @@ fi
 # Runs on every startup because this output location is not persisted storage
 # Implemented with a retry because it sometimes fails for some reason
 echo "Retrieving Oracle tnsnames file"
+GIT_ORACLE_SNIPPET="https://gitlab.k8s.cloud.statcan.ca/business-transformation/aaw/aaw-contrib-containers/snippets/515.git"
+ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  curl --url "https://gitlab.k8s.cloud.statcan.ca/api/v4/snippets/515/raw" -o /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora && break
-  echo "Failed to get the tnsnames.ora file. Attempt $i of $RETRIES_NO"
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
-  [[ $i -eq $RETRIES_NO ]] && echo "Failed to get the tnsnames.ora file after $RETRIES_NO retries"
+  [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"
   sleep ${RETRY_DELAY}
 done
 

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -213,7 +213,10 @@ ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "${ORACLE_ADMIN_PATH}/515" \
+    && mv "${ORACLE_ADMIN_PATH}/515/tnsnames.ora" "${ORACLE_ADMIN_PATH}" \
+    && rm -rf "${ORACLE_ADMIN_PATH}/515" \
+    && break
   echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
   [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"

--- a/output/jupyterlab-pytorch/start-custom.sh
+++ b/output/jupyterlab-pytorch/start-custom.sh
@@ -33,7 +33,7 @@ if [[ ! -d  ~/aaw-contrib-jupyter-notebooks ]]; then
   RETRY_DELAY=3
   for i in $(seq 1 $RETRIES_NO); do
     test -z "$GIT_EXAMPLE_NOTEBOOKS" || git clone "$GIT_EXAMPLE_NOTEBOOKS" && break
-    echo "Failed to cloned the example notebooks. Attempt $i of $RETRIES_NO"
+    echo "Failed to clone the example notebooks. Attempt $i of $RETRIES_NO"
     #if it ran all the retries, exit
     [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone example notebooks after $RETRIES_NO retries"
     sleep ${RETRY_DELAY}
@@ -208,13 +208,15 @@ fi
 # Runs on every startup because this output location is not persisted storage
 # Implemented with a retry because it sometimes fails for some reason
 echo "Retrieving Oracle tnsnames file"
+GIT_ORACLE_SNIPPET="https://gitlab.k8s.cloud.statcan.ca/business-transformation/aaw/aaw-contrib-containers/snippets/515.git"
+ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  curl --url "https://gitlab.k8s.cloud.statcan.ca/api/v4/snippets/515/raw" -o /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora && break
-  echo "Failed to get the tnsnames.ora file. Attempt $i of $RETRIES_NO"
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
-  [[ $i -eq $RETRIES_NO ]] && echo "Failed to get the tnsnames.ora file after $RETRIES_NO retries"
+  [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"
   sleep ${RETRY_DELAY}
 done
 

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -213,7 +213,10 @@ ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "${ORACLE_ADMIN_PATH}/515" \
+    && mv "${ORACLE_ADMIN_PATH}/515/tnsnames.ora" "${ORACLE_ADMIN_PATH}" \
+    && rm -rf "${ORACLE_ADMIN_PATH}/515" \
+    && break
   echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
   [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"

--- a/output/jupyterlab-tensorflow/start-custom.sh
+++ b/output/jupyterlab-tensorflow/start-custom.sh
@@ -33,7 +33,7 @@ if [[ ! -d  ~/aaw-contrib-jupyter-notebooks ]]; then
   RETRY_DELAY=3
   for i in $(seq 1 $RETRIES_NO); do
     test -z "$GIT_EXAMPLE_NOTEBOOKS" || git clone "$GIT_EXAMPLE_NOTEBOOKS" && break
-    echo "Failed to cloned the example notebooks. Attempt $i of $RETRIES_NO"
+    echo "Failed to clone the example notebooks. Attempt $i of $RETRIES_NO"
     #if it ran all the retries, exit
     [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone example notebooks after $RETRIES_NO retries"
     sleep ${RETRY_DELAY}
@@ -208,13 +208,15 @@ fi
 # Runs on every startup because this output location is not persisted storage
 # Implemented with a retry because it sometimes fails for some reason
 echo "Retrieving Oracle tnsnames file"
+GIT_ORACLE_SNIPPET="https://gitlab.k8s.cloud.statcan.ca/business-transformation/aaw/aaw-contrib-containers/snippets/515.git"
+ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  curl --url "https://gitlab.k8s.cloud.statcan.ca/api/v4/snippets/515/raw" -o /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora && break
-  echo "Failed to get the tnsnames.ora file. Attempt $i of $RETRIES_NO"
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
-  [[ $i -eq $RETRIES_NO ]] && echo "Failed to get the tnsnames.ora file after $RETRIES_NO retries"
+  [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"
   sleep ${RETRY_DELAY}
 done
 

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -213,7 +213,10 @@ ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "${ORACLE_ADMIN_PATH}/515" \
+    && mv "${ORACLE_ADMIN_PATH}/515/tnsnames.ora" "${ORACLE_ADMIN_PATH}" \
+    && rm -rf "${ORACLE_ADMIN_PATH}/515" \
+    && break
   echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
   [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"

--- a/output/remote-desktop/start-custom.sh
+++ b/output/remote-desktop/start-custom.sh
@@ -33,7 +33,7 @@ if [[ ! -d  ~/aaw-contrib-jupyter-notebooks ]]; then
   RETRY_DELAY=3
   for i in $(seq 1 $RETRIES_NO); do
     test -z "$GIT_EXAMPLE_NOTEBOOKS" || git clone "$GIT_EXAMPLE_NOTEBOOKS" && break
-    echo "Failed to cloned the example notebooks. Attempt $i of $RETRIES_NO"
+    echo "Failed to clone the example notebooks. Attempt $i of $RETRIES_NO"
     #if it ran all the retries, exit
     [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone example notebooks after $RETRIES_NO retries"
     sleep ${RETRY_DELAY}
@@ -208,13 +208,15 @@ fi
 # Runs on every startup because this output location is not persisted storage
 # Implemented with a retry because it sometimes fails for some reason
 echo "Retrieving Oracle tnsnames file"
+GIT_ORACLE_SNIPPET="https://gitlab.k8s.cloud.statcan.ca/business-transformation/aaw/aaw-contrib-containers/snippets/515.git"
+ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  curl --url "https://gitlab.k8s.cloud.statcan.ca/api/v4/snippets/515/raw" -o /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora && break
-  echo "Failed to get the tnsnames.ora file. Attempt $i of $RETRIES_NO"
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
-  [[ $i -eq $RETRIES_NO ]] && echo "Failed to get the tnsnames.ora file after $RETRIES_NO retries"
+  [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"
   sleep ${RETRY_DELAY}
 done
 

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -213,7 +213,10 @@ ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "${ORACLE_ADMIN_PATH}/515" \
+    && mv "${ORACLE_ADMIN_PATH}/515/tnsnames.ora" "${ORACLE_ADMIN_PATH}" \
+    && rm -rf "${ORACLE_ADMIN_PATH}/515" \
+    && break
   echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
   [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"

--- a/output/rstudio/start-custom.sh
+++ b/output/rstudio/start-custom.sh
@@ -33,7 +33,7 @@ if [[ ! -d  ~/aaw-contrib-jupyter-notebooks ]]; then
   RETRY_DELAY=3
   for i in $(seq 1 $RETRIES_NO); do
     test -z "$GIT_EXAMPLE_NOTEBOOKS" || git clone "$GIT_EXAMPLE_NOTEBOOKS" && break
-    echo "Failed to cloned the example notebooks. Attempt $i of $RETRIES_NO"
+    echo "Failed to clone the example notebooks. Attempt $i of $RETRIES_NO"
     #if it ran all the retries, exit
     [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone example notebooks after $RETRIES_NO retries"
     sleep ${RETRY_DELAY}
@@ -208,13 +208,15 @@ fi
 # Runs on every startup because this output location is not persisted storage
 # Implemented with a retry because it sometimes fails for some reason
 echo "Retrieving Oracle tnsnames file"
+GIT_ORACLE_SNIPPET="https://gitlab.k8s.cloud.statcan.ca/business-transformation/aaw/aaw-contrib-containers/snippets/515.git"
+ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  curl --url "https://gitlab.k8s.cloud.statcan.ca/api/v4/snippets/515/raw" -o /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora && break
-  echo "Failed to get the tnsnames.ora file. Attempt $i of $RETRIES_NO"
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
-  [[ $i -eq $RETRIES_NO ]] && echo "Failed to get the tnsnames.ora file after $RETRIES_NO retries"
+  [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"
   sleep ${RETRY_DELAY}
 done
 

--- a/output/sas/start-custom.sh
+++ b/output/sas/start-custom.sh
@@ -213,7 +213,10 @@ ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "${ORACLE_ADMIN_PATH}/515" \
+    && mv "${ORACLE_ADMIN_PATH}/515/tnsnames.ora" "${ORACLE_ADMIN_PATH}" \
+    && rm -rf "${ORACLE_ADMIN_PATH}/515" \
+    && break
   echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
   [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"

--- a/output/sas/start-custom.sh
+++ b/output/sas/start-custom.sh
@@ -33,7 +33,7 @@ if [[ ! -d  ~/aaw-contrib-jupyter-notebooks ]]; then
   RETRY_DELAY=3
   for i in $(seq 1 $RETRIES_NO); do
     test -z "$GIT_EXAMPLE_NOTEBOOKS" || git clone "$GIT_EXAMPLE_NOTEBOOKS" && break
-    echo "Failed to cloned the example notebooks. Attempt $i of $RETRIES_NO"
+    echo "Failed to clone the example notebooks. Attempt $i of $RETRIES_NO"
     #if it ran all the retries, exit
     [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone example notebooks after $RETRIES_NO retries"
     sleep ${RETRY_DELAY}
@@ -208,13 +208,15 @@ fi
 # Runs on every startup because this output location is not persisted storage
 # Implemented with a retry because it sometimes fails for some reason
 echo "Retrieving Oracle tnsnames file"
+GIT_ORACLE_SNIPPET="https://gitlab.k8s.cloud.statcan.ca/business-transformation/aaw/aaw-contrib-containers/snippets/515.git"
+ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  curl --url "https://gitlab.k8s.cloud.statcan.ca/api/v4/snippets/515/raw" -o /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora && break
-  echo "Failed to get the tnsnames.ora file. Attempt $i of $RETRIES_NO"
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
-  [[ $i -eq $RETRIES_NO ]] && echo "Failed to get the tnsnames.ora file after $RETRIES_NO retries"
+  [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"
   sleep ${RETRY_DELAY}
 done
 

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -213,7 +213,10 @@ ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "${ORACLE_ADMIN_PATH}/515" \
+    && mv "${ORACLE_ADMIN_PATH}/515/tnsnames.ora" "${ORACLE_ADMIN_PATH}" \
+    && rm -rf "${ORACLE_ADMIN_PATH}/515" \
+    && break
   echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
   [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"

--- a/resources/common/start-custom.sh
+++ b/resources/common/start-custom.sh
@@ -33,7 +33,7 @@ if [[ ! -d  ~/aaw-contrib-jupyter-notebooks ]]; then
   RETRY_DELAY=3
   for i in $(seq 1 $RETRIES_NO); do
     test -z "$GIT_EXAMPLE_NOTEBOOKS" || git clone "$GIT_EXAMPLE_NOTEBOOKS" && break
-    echo "Failed to cloned the example notebooks. Attempt $i of $RETRIES_NO"
+    echo "Failed to clone the example notebooks. Attempt $i of $RETRIES_NO"
     #if it ran all the retries, exit
     [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone example notebooks after $RETRIES_NO retries"
     sleep ${RETRY_DELAY}
@@ -208,13 +208,15 @@ fi
 # Runs on every startup because this output location is not persisted storage
 # Implemented with a retry because it sometimes fails for some reason
 echo "Retrieving Oracle tnsnames file"
+GIT_ORACLE_SNIPPET="https://gitlab.k8s.cloud.statcan.ca/business-transformation/aaw/aaw-contrib-containers/snippets/515.git"
+ORACLE_ADMIN_PATH="/opt/oracle/instantclient_23_5/network/admin"
 RETRIES_NO=5
 RETRY_DELAY=3
 for i in $(seq 1 $RETRIES_NO); do
-  curl --url "https://gitlab.k8s.cloud.statcan.ca/api/v4/snippets/515/raw" -o /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora && break
-  echo "Failed to get the tnsnames.ora file. Attempt $i of $RETRIES_NO"
+  test -z "$GIT_ORACLE_SNIPPET" || git clone "$GIT_ORACLE_SNIPPET" "$ORACLE_ADMIN_PATH" && rm -rf "${ORACLE_ADMIN_PATH}/.git" && break
+  echo "Failed to clone the tnsnames.ora file. Attempt $i of $RETRIES_NO"
   #if it ran all the retries, exit
-  [[ $i -eq $RETRIES_NO ]] && echo "Failed to get the tnsnames.ora file after $RETRIES_NO retries"
+  [[ $i -eq $RETRIES_NO ]] && echo "Failed to clone the tnsnames.ora after $RETRIES_NO retries"
   sleep ${RETRY_DELAY}
 done
 


### PR DESCRIPTION
# Description

With the curl command, it would still copy the output of the curl to the output file, even on an error. We dont want that as it overrites the file, which we only want to do on success. Switched to a git clone command like how our example notebooks get done.

![image](https://github.com/user-attachments/assets/9b1f685a-7be7-4f5e-b60b-d32c06b44cd3)


# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
