### PR TITLE
roll back OpenM++ version

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -237,11 +237,10 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ENV OMPP_VERSION="1.17.5"
-# IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ENV OMPP_PKG_DATE="20241021"
+ENV OMPP_VERSION="1.17.1"
+ENV OMPP_PKG_DATE="20240322"
 # Sha needs to be manually generated.
-ARG SHA256ompp=79c4bf6e09c9c51f33986251f1f44279f29d4fe669b6e8f7d7597a406d24b5a9
+ARG SHA256ompp=04fc24ad2ed6d6ef1e29430885b77c766eba85e7c5e69ba4c11acb838d712609
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -259,8 +259,8 @@ RUN apt-get update --yes \
     && rm -f /tmp/ompp.tar.gz \
 # Customize and rebuild omp-ui for jupyter-ompp-proxy install
 # issue with making a relative publicPath https://github.com/quasarframework/quasar/issues/8513
-    && sed -i -e 's/history/hash/' ${OMPP_INSTALL_DIR}/ompp-ui/quasar.config.js \
-    && sed -i -e "s/OMS_URL:.*''/OMS_URL: '.'/" ${OMPP_INSTALL_DIR}/ompp-ui/quasar.config.js \
+    && sed -i -e 's/history/hash/' ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && sed -i -e "s/OMS_URL:.*''/OMS_URL: '.'/" ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
     && npm install --prefix ${OMPP_INSTALL_DIR}/ompp-ui @babel/traverse@7.23.2\
     && npm run build --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
     && rm -r ${OMPP_INSTALL_DIR}/html \

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -485,7 +485,7 @@ ENV OMPP_VERSION="1.17.1"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ENV OMPP_PKG_DATE="20240322"
 # Sha needs to be manually generated.
-ARG SHA256ompp=04fc24ad2ed6d6ef1e29430885b77c766eba85e7c5e69ba4c11acb838d712609
+ARG SHA256ompp=76c16dd8e2ca637006b92c4cc36541cedc776dda1a06fcf0702859271ca78ac3
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -481,11 +481,11 @@ COPY minio-icon.png $RESOURCES_PATH/minio-icon.png
 COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 
 # Install OpenM++
-ENV OMPP_VERSION="1.17.5"
+ENV OMPP_VERSION="1.17.1"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ENV OMPP_PKG_DATE="20241021"
+ENV OMPP_PKG_DATE="20240322"
 # Sha needs to be manually generated.
-ARG SHA256ompp=79084a009f3bad3c0d81cb12ccc844458d29b70d199352233aad3d94489427c9
+ARG SHA256ompp=04fc24ad2ed6d6ef1e29430885b77c766eba85e7c5e69ba4c11acb838d712609
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100

--- a/images/remote-desktop/desktop-files/openmpp.desktop
+++ b/images/remote-desktop/desktop-files/openmpp.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=OpenM++
-Exec=/opt/openmpp/1.17.5/bin/ompp_ui_linux.sh
+Exec=/opt/openmpp/1.17.1/bin/ompp_ui_linux.sh
 Icon=/resources/openmpp.png
 Terminal=false
 Categories=Development;


### PR DESCRIPTION
Fix issue in https://github.com/StatCan/aaw/issues/2016


The newer version of OpenM++ need `glibc v2.38`, but on our current version we have `glibc v2.35`
This version is set by the Ubuntu version, which is set by our base image. 

We can upgrade OpenM++ once https://github.com/StatCan/aaw/issues/2014 is finished. 