### PR TITLE
Revert "Bryan update r 4.4.1 (#742)"

### DIFF
--- a/docker-bits/6_rstudio.Dockerfile
+++ b/docker-bits/6_rstudio.Dockerfile
@@ -15,16 +15,9 @@ ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 ENV SPARK_HOME="/opt/conda/lib/python3.11/site-packages/pyspark"
 
 # Install some default R packages
-# rpy2 is installed by upstream, I don't know if anyone uses it.
-# ryp2 was causing problems with R 4.4.1, so I removed it from the 
-# mamba install. rpy2 is reinstalled with pip below.
-# when we next upgrade R, let's try to restore rpy2 to its original state
-# which means just remove mamba remove rpy2 and remove pip install rpy2
-RUN mamba remove rpy2 && \
-    mamba install --quiet --yes \
+RUN mamba install --quiet --yes \
       'r-arrow' \
       'r-aws.s3' \
-      'r-base=4.4.1' \
       'r-catools' \
       'r-e1071' \
       'r-hdf5r' \
@@ -36,7 +29,6 @@ RUN mamba remove rpy2 && \
       'r-sparklyr' \
       'r-tidyverse' \
     && \
-    pip install rpy2 && \
     clean-layer.sh && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -252,16 +252,9 @@ ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 ENV SPARK_HOME="/opt/conda/lib/python3.11/site-packages/pyspark"
 
 # Install some default R packages
-# rpy2 is installed by upstream, I don't know if anyone uses it.
-# ryp2 was causing problems with R 4.4.1, so I removed it from the 
-# mamba install. rpy2 is reinstalled with pip below.
-# when we next upgrade R, let's try to restore rpy2 to its original state
-# which means just remove mamba remove rpy2 and remove pip install rpy2
-RUN mamba remove rpy2 && \
-    mamba install --quiet --yes \
+RUN mamba install --quiet --yes \
       'r-arrow' \
       'r-aws.s3' \
-      'r-base=4.4.1' \
       'r-catools' \
       'r-e1071' \
       'r-hdf5r' \
@@ -273,7 +266,6 @@ RUN mamba remove rpy2 && \
       'r-sparklyr' \
       'r-tidyverse' \
     && \
-    pip install rpy2 && \
     clean-layer.sh && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -274,16 +274,9 @@ ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 ENV SPARK_HOME="/opt/conda/lib/python3.11/site-packages/pyspark"
 
 # Install some default R packages
-# rpy2 is installed by upstream, I don't know if anyone uses it.
-# ryp2 was causing problems with R 4.4.1, so I removed it from the 
-# mamba install. rpy2 is reinstalled with pip below.
-# when we next upgrade R, let's try to restore rpy2 to its original state
-# which means just remove mamba remove rpy2 and remove pip install rpy2
-RUN mamba remove rpy2 && \
-    mamba install --quiet --yes \
+RUN mamba install --quiet --yes \
       'r-arrow' \
       'r-aws.s3' \
-      'r-base=4.4.1' \
       'r-catools' \
       'r-e1071' \
       'r-hdf5r' \
@@ -295,7 +288,6 @@ RUN mamba remove rpy2 && \
       'r-sparklyr' \
       'r-tidyverse' \
     && \
-    pip install rpy2 && \
     clean-layer.sh && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -381,16 +381,9 @@ ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 ENV SPARK_HOME="/opt/conda/lib/python3.11/site-packages/pyspark"
 
 # Install some default R packages
-# rpy2 is installed by upstream, I don't know if anyone uses it.
-# ryp2 was causing problems with R 4.4.1, so I removed it from the 
-# mamba install. rpy2 is reinstalled with pip below.
-# when we next upgrade R, let's try to restore rpy2 to its original state
-# which means just remove mamba remove rpy2 and remove pip install rpy2
-RUN mamba remove rpy2 && \
-    mamba install --quiet --yes \
+RUN mamba install --quiet --yes \
       'r-arrow' \
       'r-aws.s3' \
-      'r-base=4.4.1' \
       'r-catools' \
       'r-e1071' \
       'r-hdf5r' \
@@ -402,7 +395,6 @@ RUN mamba remove rpy2 && \
       'r-sparklyr' \
       'r-tidyverse' \
     && \
-    pip install rpy2 && \
     clean-layer.sh && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -252,16 +252,9 @@ ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 ENV SPARK_HOME="/opt/conda/lib/python3.11/site-packages/pyspark"
 
 # Install some default R packages
-# rpy2 is installed by upstream, I don't know if anyone uses it.
-# ryp2 was causing problems with R 4.4.1, so I removed it from the 
-# mamba install. rpy2 is reinstalled with pip below.
-# when we next upgrade R, let's try to restore rpy2 to its original state
-# which means just remove mamba remove rpy2 and remove pip install rpy2
-RUN mamba remove rpy2 && \
-    mamba install --quiet --yes \
+RUN mamba install --quiet --yes \
       'r-arrow' \
       'r-aws.s3' \
-      'r-base=4.4.1' \
       'r-catools' \
       'r-e1071' \
       'r-hdf5r' \
@@ -273,7 +266,6 @@ RUN mamba remove rpy2 && \
       'r-sparklyr' \
       'r-tidyverse' \
     && \
-    pip install rpy2 && \
     clean-layer.sh && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -412,16 +412,9 @@ ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 ENV SPARK_HOME="/opt/conda/lib/python3.11/site-packages/pyspark"
 
 # Install some default R packages
-# rpy2 is installed by upstream, I don't know if anyone uses it.
-# ryp2 was causing problems with R 4.4.1, so I removed it from the 
-# mamba install. rpy2 is reinstalled with pip below.
-# when we next upgrade R, let's try to restore rpy2 to its original state
-# which means just remove mamba remove rpy2 and remove pip install rpy2
-RUN mamba remove rpy2 && \
-    mamba install --quiet --yes \
+RUN mamba install --quiet --yes \
       'r-arrow' \
       'r-aws.s3' \
-      'r-base=4.4.1' \
       'r-catools' \
       'r-e1071' \
       'r-hdf5r' \
@@ -433,7 +426,6 @@ RUN mamba remove rpy2 && \
       'r-sparklyr' \
       'r-tidyverse' \
     && \
-    pip install rpy2 && \
     clean-layer.sh && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER


### PR DESCRIPTION
This reverts commit ec0aa3fa842af96911a30f70b6df85614502dd2f.

# Description

**What your PR adds/fixes/removes**

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
